### PR TITLE
Use simd4 memorylayout when calculating buffer length

### DIFF
--- a/Tests/Operations/GEMM.swift
+++ b/Tests/Operations/GEMM.swift
@@ -241,8 +241,8 @@ struct MFA_GEMM: GEMM, MFA_Operation {
             UInt64(truncatingIfNeeded: i * byteStrideD))
         }
         
-        let bufferLength = buffer.count * MemoryLayout<SIMD3<UInt64>>.stride
-        assert(MemoryLayout<SIMD3<UInt64>>.stride == 8 * 4)
+        let bufferLength = buffer.count * MemoryLayout<SIMD4<UInt64>>.stride
+        assert(MemoryLayout<SIMD4<UInt64>>.stride == 8 * 4)
         encoder.setBytes(buffer.baseAddress!, length: bufferLength, index: 10)
       }
     } else {


### PR DESCRIPTION
Both `MemoryLayout<SIMD4<UInt64>>.stride` and `MemoryLayout<SIMD3<UInt64>>.stride` are `32` (at least on my machine), so this absolutely does not matter.
My eyelid just started twitching from seeing buffer defined as `SIMD4` and then using `SIMD3` for the stride hehe. Feel free to ignore ;)