### PR TITLE
Allow MFA to be configured to use float32 as accumulator

### DIFF
--- a/Tests/Operations/Attention.swift
+++ b/Tests/Operations/Attention.swift
@@ -36,6 +36,7 @@ struct Attention_Parameters: Hashable, Equatable {
   var batched: Bool
   var masked: Bool
   var blockSparse: Bool
+  var accumulateInFloat: Bool
   
   // These are only needed by MPSGraph; MFA supports dynamic batch size.
   var batchDimensionsQ: [Int]?
@@ -83,6 +84,7 @@ struct MFA_Attention: Attention, MFA_Operation {
     constants.setConstantValue(&pcopy.batched, type: .bool, index: 100)
     constants.setConstantValue(&pcopy.masked, type: .bool, index: 50000)
     constants.setConstantValue(&pcopy.blockSparse, type: .bool, index: 102)
+    constants.setConstantValue(&pcopy.accumulateInFloat, type: .bool, index: 114)
     
     var triangular = false
     #if false

--- a/Tests/Tensor/Tensor.swift
+++ b/Tests/Tensor/Tensor.swift
@@ -217,7 +217,8 @@ extension Tensor {
     transposeK: Bool = true,
     transposeV: Bool = false,
     transposeO: Bool = false,
-    blockSparse: Bool = false
+    blockSparse: Bool = false,
+    accumulateInFloat: Bool = false
   ) {
     assert(self.typeAndBackendMatches(queries))
     assert(self.typeAndBackendMatches(keys))
@@ -319,7 +320,7 @@ extension Tensor {
       Q_trans: transposeQ, K_trans: transposeK,
       V_trans: transposeV, O_trans: transposeO,
       batched: batched, masked: mask != nil,
-      blockSparse: blockSparse)
+      blockSparse: blockSparse, accumulateInFloat: accumulateInFloat)
     if blockSparse {
       precondition(mask != nil, "Block sparsity requires a mask.")
     }

--- a/Tests/Test Cases/AttentionPerfTests.swift
+++ b/Tests/Test Cases/AttentionPerfTests.swift
@@ -531,7 +531,8 @@ class AttentionPerfTests: MFATestCase {
               values: tensors.v,
               mask: tensors.mask,
               transposeK: true,
-              blockSparse: backend == .mfaBlockSparse
+              blockSparse: backend == .mfaBlockSparse,
+              accumulateInFloat: MFATestCase.accumulateInFloat
             )
           }
           tensorBackend.markLastCommand()
@@ -566,7 +567,8 @@ class AttentionPerfTests: MFATestCase {
           values: mfaTensors.v,
           mask: mfaTensors.mask,
           transposeK: true,
-          blockSparse: backend == .mfaBlockSparse)
+          blockSparse: backend == .mfaBlockSparse,
+          accumulateInFloat: MFATestCase.accumulateInFloat)
       }
       
       _ExecutionContext.withDefaultBackend(mps) {
@@ -576,7 +578,7 @@ class AttentionPerfTests: MFATestCase {
             keys: mpsTensors.k,
             values: mpsTensors.v,
             mask: mpsTensors.mask,
-            transposeK: true)
+            transposeK: true, accumulateInFloat: MFATestCase.accumulateInFloat)
         }
       }
       

--- a/Tests/Test Cases/AttentionTest.swift
+++ b/Tests/Test Cases/AttentionTest.swift
@@ -110,7 +110,7 @@ func showAttentionTest() {
       expected_O.attention(
         queries: expected_Q, keys: expected_K, values: expected_V,
         mask: expected_mask,
-        transposeK: true, transposeO: true)
+        transposeK: true, transposeO: true, accumulateInFloat: MFATestCase.accumulateInFloat)
     }
   }
   
@@ -119,7 +119,7 @@ func showAttentionTest() {
       actual_O.attention(
         queries: actual_Q, keys: actual_K, values: actual_V,
         mask: actual_mask,
-        transposeK: true, transposeO: true, blockSparse: true)
+        transposeK: true, transposeO: true, blockSparse: true, accumulateInFloat: MFATestCase.accumulateInFloat)
     }
   }
   

--- a/Tests/Test Cases/CorrectnessTests.swift
+++ b/Tests/Test Cases/CorrectnessTests.swift
@@ -419,7 +419,7 @@ class CorrectnessTests: MFATestCase {
           queries: Q, keys: K, values: V, mask: mask,
           transposeQ: Q_trans, transposeK: K_trans,
           transposeV: V_trans, transposeO: O_trans,
-          blockSparse: blockSparse)
+          blockSparse: blockSparse, accumulateInFloat: MFATestCase.accumulateInFloat)
       }
       
       if ghost {

--- a/Tests/Test Cases/MFATestCase.swift
+++ b/Tests/Test Cases/MFATestCase.swift
@@ -10,10 +10,12 @@ import Foundation
 class MFATestCase {
   // Global setting for the precision used in tests.
   #if arch(arm64)
-  typealias Real = Float32
+  typealias Real = Float16
   #else
   typealias Real = Float
   #endif
+  
+  static let accumulateInFloat = true
   
   class func typeDescription() -> String {
     fatalError("Not implemented.")


### PR DESCRIPTION
One difference between MFA and xformer is that xformer has default fp32 accumulator (actually only uses fp32 accumulator if I remembered correctly). The side-effect is that some trained models works with fp32 accumulator but will nan on fp16 accumulator.

Previously, we worked around this problem by passing fp32 tensors into MFA prior to the attention op, but for models that requires large batch (such as Stable Video Attention), the cost of doing conversion outside is pretty steep.

This PR introduced a configuration bool constant float_accumulator which will configure the attention op so for these cases, we can do the upcast at MFA side, to avoid the cost of conversion with large MTLBuffer.

What has been done:

1. Validated this implementation against MFA test suite for its correctness.
2. Provided graph to show minimal change in perf characteristics with / wo float accumulator.

With FP16 accumulator:
![attn_fp16_original](https://github.com/philipturner/metal-flash-attention/assets/127987/9865ac67-02eb-427b-89c9-27892a96fa47)

With FP32 accumulator:
![fig_fp16_fp32acc](https://github.com/philipturner/metal-flash-attention/assets/127987/53fd6127-b077-4811-8bc5-d840593fdfe7)

What's left:

- [x] Validate with this change, we will no longer nan with SVD models.