### PR TITLE
Fix grouped query support

### DIFF
--- a/Tests/Operations/Attention.swift
+++ b/Tests/Operations/Attention.swift
@@ -71,6 +71,7 @@ struct MFA_Attention: Attention, MFA_Operation {
     constants.setConstantValue(&pcopy.C, type: .uint, index: 1)
     constants.setConstantValue(&pcopy.H, type: .uint, index: 2)
     constants.setConstantValue(&pcopy.D, type: .uint, index: 3)
+    constants.setConstantValue(&pcopy.H, type: .uint, index: 4)
     constants.setConstantValue(&pcopy.Q_trans, type: .bool, index: 10)
     constants.setConstantValue(&pcopy.K_trans, type: .bool, index: 11)
     constants.setConstantValue(&pcopy.V_trans, type: .bool, index: 12)


### PR DESCRIPTION
For grouped query available in Mistral, it is requires a different H (conventionally H / Hk) for key / value. Conventionally, H_k is also smaller than H and H % H_k == 0.

We can leverage these for grouped query implementation. But for now, I am sticking with the original design to use head_offsets for this. But we still need to pass the H_k to compute the right offset in case batched == true.

There is also a tiny place that we use gid.y directly to compute the Output offsets, which is not going to be wrong for the particular grouped query setup we have in Mistral model, I am not sure if I need to fix that in this PR.