### PR TITLE
Replace __asm inline assembly with monolithic IR + in-process MetalASM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,11 +18,15 @@ let package = Package(
       name: "FlashAttention",
       targets: ["FlashAttention"]),
   ],
+  dependencies: [
+    .package(url: "https://github.com/mpsops/MetalASM.git", from: "0.1.2"),
+  ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.
     // Targets can depend on other targets in this package and products from dependencies.
     .target(
-      name: "FlashAttention"),
+      name: "FlashAttention",
+      dependencies: ["MetalASM"]),
     .testTarget(
       name: "FlashAttentionTests",
       dependencies: ["FlashAttention"]),

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
       targets: ["FlashAttention"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/mpsops/MetalASM.git", from: "0.1.2"),
+    .package(url: "https://github.com/mpsops/MetalASM.git", exact: "0.1.2"),
   ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sources/FlashAttention/Attention/AttentionDescriptor/AttentionDescriptor+PipelineCache.swift
+++ b/Sources/FlashAttention/Attention/AttentionDescriptor/AttentionDescriptor+PipelineCache.swift
@@ -1,0 +1,134 @@
+//
+//  AttentionDescriptor+PipelineCache.swift
+//  FlashAttention
+//
+
+import Metal
+import MetalASM
+
+/// Observable log for pipeline compilation events.
+public class FlashAttentionLog: @unchecked Sendable {
+  public static let shared = FlashAttentionLog()
+  private let lock = NSLock()
+  private var _entries: [String] = []
+  public var onChange: (() -> Void)?
+
+  public var entries: [String] {
+    lock.lock()
+    defer { lock.unlock() }
+    return _entries
+  }
+
+  public func append(_ message: String) {
+    lock.lock()
+    _entries.append(message)
+    lock.unlock()
+    print(message)
+    DispatchQueue.main.async { self.onChange?() }
+  }
+
+  public func clear() {
+    lock.lock()
+    _entries.removeAll()
+    lock.unlock()
+    DispatchQueue.main.async { self.onChange?() }
+  }
+}
+
+extension AttentionKernel {
+  public typealias PipelineValue = (
+    kernel: AttentionKernel, pipeline: MTLComputePipelineState)
+
+  public static var pipelineCache: [
+    AttentionDescriptor: [AttentionKernelType: PipelineValue]] = [:]
+}
+
+extension AttentionKernel {
+  /// Lazily get a pipeline for a specific kernel type.
+  /// Compiles only the requested kernel on first access; cached thereafter.
+  public static func pipeline(
+    for descriptor: AttentionDescriptor, type: AttentionKernelType
+  ) -> PipelineValue {
+    if let cached = pipelineCache[descriptor]?[type] {
+      return cached
+    }
+    compileSingle(descriptor: descriptor, type: type)
+    return pipelineCache[descriptor]![type]!
+  }
+
+  /// Eagerly register all kernel types (or just forward with inferenceOnly).
+  /// Use this for warmup screens where you want to pay compile cost upfront.
+  public static func register(
+    descriptor: AttentionDescriptor, inferenceOnly: Bool = false
+  ) {
+    let types: [AttentionKernelType] = inferenceOnly
+      ? [.forward]
+      : [.forward, .backwardQuery, .backwardKeyValue]
+
+    for type in types {
+      if pipelineCache[descriptor]?[type] != nil { continue }
+      compileSingle(descriptor: descriptor, type: type)
+    }
+  }
+
+  /// Compile a single kernel type for the given descriptor.
+  private static func compileSingle(
+    descriptor: AttentionDescriptor, type: AttentionKernelType
+  ) {
+    guard let matrixDimensions = descriptor.matrixDimensions,
+          let transposeState = descriptor.transposeState else {
+      fatalError("Descriptor was incomplete.")
+    }
+
+    let device = MTLContext.global.device
+    let R = matrixDimensions.row
+    let C = matrixDimensions.column
+    let D = UInt32(matrixDimensions.head)
+
+    var monoDesc = AttentionKernel.MonolithicDescriptor()
+    monoDesc.R = R
+    monoDesc.C = C
+    monoDesc.leadingDimensions[.Q] = transposeState.Q ? R : D
+    monoDesc.leadingDimensions[.K] = transposeState.K ? C : D
+    monoDesc.leadingDimensions[.V] = transposeState.V ? C : D
+    monoDesc.leadingDimensions[.O] = transposeState.O ? R : D
+    monoDesc.leadingDimensions[.dO] = transposeState.O ? R : D
+    monoDesc.leadingDimensions[.dV] = transposeState.V ? C : D
+    monoDesc.leadingDimensions[.dK] = transposeState.K ? C : D
+    monoDesc.leadingDimensions[.dQ] = transposeState.Q ? R : D
+
+    let t1 = CFAbsoluteTimeGetCurrent()
+    let kernelDesc = descriptor.kernelDescriptor(type: type)
+    let kernel = AttentionKernel(descriptor: kernelDesc)
+
+    let ir = kernel.createSource(descriptor: monoDesc)
+    let t2 = CFAbsoluteTimeGetCurrent()
+
+    #if os(macOS)
+    let metallibData = try! MetalASM.assemble(
+      ir: ir, platform: .macOS(version: 26))
+    #elseif os(iOS)
+    let metallibData = try! MetalASM.assemble(
+      ir: ir, platform: .iOS(version: 26))
+    #endif
+    let t3 = CFAbsoluteTimeGetCurrent()
+
+    let dispatchData = metallibData.withUnsafeBytes {
+      DispatchData(bytes: $0)
+    }
+    let library = try! device.makeLibrary(data: dispatchData)
+    let function = library.makeFunction(name: "attention")!
+    let pipeline = try! device.makeComputePipelineState(function: function)
+    let t4 = CFAbsoluteTimeGetCurrent()
+
+    FlashAttentionLog.shared.append(
+      String(format: "  %@: IR=%.0fms (%dKB) asm=%.0fms gpu=%.0fms",
+             "\(type)", (t2-t1)*1000, ir.utf8.count / 1024, (t3-t2)*1000, (t4-t3)*1000))
+    FlashAttentionLog.shared.append("    \(MetalASM._lastTiming)")
+
+    if pipelineCache[descriptor] == nil {
+      pipelineCache[descriptor] = [:]
+    }
+    pipelineCache[descriptor]![type] = (kernel, pipeline)
+  }
+}

--- a/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+BackwardIR.swift
+++ b/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+BackwardIR.swift
@@ -1,0 +1,581 @@
+//
+//  AttentionKernel+BackwardIR.swift
+//  FlashAttention
+//
+//  Backward attention kernel IR generation.
+//
+//  backwardQuery:    D = dO·O; for c: S=Q*K^T, P=softmax(S,L), dP=dO*V^T, dS=P*(dP-D), dQ+=dS*K
+//  backwardKeyValue: for r: S^T=K*Q^T, P^T=softmax(S^T,L), dV+=P^T*dO, dP^T=V*dO^T, dS^T=P^T*(dP^T-D), dK+=dS^T*Q
+//
+
+extension AttentionKernel {
+
+  // MARK: - Backward Query
+
+  func generateBackwardQueryKernel(
+    desc: MonolithicDescriptor,
+    R: UInt32, C: UInt32, D: UInt32,
+    blockP: UInt16, blockT: UInt16, blockH: UInt16,
+    parallelDim: UInt32, traversalDim: UInt32,
+    paddedD: UInt32, headEdge: UInt32,
+    headLoopFloor: UInt32,
+    sSramCount: Int,
+    scaleFactor: Float, tgFloats: Int,
+    leadingDim: (AttentionOperand) -> UInt32,
+    leadingBlockDim: (AttentionOperand) -> UInt32,
+    memPrec: (AttentionOperand) -> GEMMOperandPrecision,
+    regPrec: (AttentionOperand) -> GEMMOperandPrecision,
+    memSize: (AttentionOperand) -> UInt32
+  ) -> String {
+    var ir = ""
+
+    let regS = regPrec(.S)
+    let regP = regPrec(.P)
+    let regdP = regPrec(.dP)
+    let regdS = regPrec(.dS)
+    let regQ = regPrec(.Q)
+    let regK = regPrec(.K)
+    let regV = regPrec(.V)
+    let regdO = regPrec(.dO)
+    let regdQ = regPrec(.dQ)
+    let regO = regPrec(.O)
+    let memQ = memPrec(.Q)
+    let memK = memPrec(.K)
+    let memV = memPrec(.V)
+    let memO = memPrec(.O)
+    let memdO = memPrec(.dO)
+    let memdQ = memPrec(.dQ)
+    let memL = memPrec(.L)
+    let memD = memPrec(.D)
+
+    let isCachedQ = cached(.Q)
+    let isCacheddO = cached(.dO)
+    let isCacheddQ = cached(.dQ)
+
+    // dQ accumulator count = paddedD / 8 (always full head dim)
+    let dqCount = Int(paddedD / 8)
+
+    // Derivative scale factor: 1/sqrt(D) (no log2(e) factor)
+    let derivScale = 1.0 / Float(headDimension).squareRoot()
+
+    // MARK: - Setup
+
+    ir += "  ; === Backward Query setup ===\n"
+
+    // Cache load Q if cached
+    if isCachedQ {
+      ir += generateCacheLoad(
+        operand: .Q, prefix: "cq_",
+        parallelDim: parallelDim, D: D, paddedD: paddedD,
+        blockP: blockP, blockH: blockH,
+        leadingDim: leadingDim(.Q), leadingBlockDim: leadingBlockDim(.Q),
+        memPrec: memQ, regPrec: regQ,
+        transposed: transposed(.Q)
+      )
+    }
+
+    // Cache load dO if cached
+    if isCacheddO {
+      ir += generateCacheLoad(
+        operand: .dO, prefix: "cdo_",
+        parallelDim: parallelDim, D: D, paddedD: paddedD,
+        blockP: blockP, blockH: blockH,
+        leadingDim: leadingDim(.dO), leadingBlockDim: leadingBlockDim(.dO),
+        memPrec: memdO, regPrec: regdO,
+        transposed: transposed(.dO)
+      )
+    }
+
+    // Initialize dQ accumulators to zero
+    for i in 0..<dqCount {
+      ir += "  \(irZeroVec64(result: "%dq_init_\(i)", precision: regdQ))\n"
+    }
+
+    // Load L scalar for this row
+    // L_sram = L[clamped_par_off]
+    let elemSizeL = UInt32(memL.size)
+    ir += "  ; Load L scalar\n"
+    ir += "  %L_off = zext i32 %clamped_par_off to i64\n"
+    ir += "  %L_byte = mul i64 %L_off, \(elemSizeL)\n"
+    ir += "  %L_ptr = getelementptr i8, i8 addrspace(1)* %L_buf, i64 %L_byte\n"
+    if memL == .FP32 {
+      ir += "  %L_typed = bitcast i8 addrspace(1)* %L_ptr to float addrspace(1)*\n"
+      ir += "  %L_sram = load float, float addrspace(1)* %L_typed\n"
+    } else {
+      let tL = irTypeName(memL)
+      ir += "  %L_typed = bitcast i8 addrspace(1)* %L_ptr to \(tL) addrspace(1)*\n"
+      ir += "  %L_raw = load \(tL), \(tL) addrspace(1)* %L_typed\n"
+      ir += "  %L_sram = fpext \(tL) %L_raw to float\n"
+    }
+
+    // Compute D = sum(dO * O) across the head dimension
+    // D_sram = reduce_sum(dO[row,:] * O[row,:])
+    ir += generateComputeD(
+      prefix: "cd_",
+      D: D, paddedD: paddedD, blockH: blockH,
+      headLoopFloor: headLoopFloor, headEdge: headEdge,
+      parallelDim: parallelDim,
+      cachedO: false, cacheddO: isCacheddO,
+      leadingDimO: leadingDim(.O), leadingDimdO: leadingDim(.dO),
+      memO: memO, regO: regO,
+      memdO: memdO, regdO: regdO,
+      transposedO: transposed(.O), transposeddO: transposed(.dO)
+    )
+
+    // MARK: - Traversal Loop
+
+    ir += """
+
+      ; === Traversal loop ===
+      br label %bq_before_loop
+    bq_before_loop:
+      br label %bq_loop_header
+
+    bq_loop_header:
+      %bq_c = phi i32 [0, %bq_before_loop], [%bq_c_next, %bq_loop_latch]
+
+    """
+
+    // Phi nodes for dQ accumulators
+    for i in 0..<dqCount {
+      ir += "  %dq_phi_\(i) = phi \(irVecType(regdQ)) [%dq_init_\(i), %bq_before_loop], [%dq_acc_\(i), %bq_loop_latch]\n"
+    }
+
+    ir += """
+
+      %bq_loop_done = icmp uge i32 %bq_c, \(traversalDim)
+      br i1 %bq_loop_done, label %bq_cleanup, label %bq_loop_body
+
+    bq_loop_body:
+
+    """
+
+    // Step 1: S = Q * K^T (outer product)
+    for i in 0..<sSramCount {
+      ir += "  \(irZeroVec64(result: "%s_init_\(i)", precision: regS))\n"
+    }
+
+    ir += generateOuterProduct(
+      prefix: "qo_",
+      A: .Q, B: .K, C_name: "s",
+      sSramCount: sSramCount,
+      blockP: blockP, blockT: blockT, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim, traversalDim: traversalDim,
+      traversalOffset: "%bq_c",
+      regA: regQ, regB: regK, regC: regS,
+      memA: memQ, memB: memK,
+      leadingDimA: leadingDim(.Q), leadingDimB: leadingDim(.K),
+      leadingBlockDimA: leadingBlockDim(.Q), leadingBlockDimB: leadingBlockDim(.K),
+      cachedA: isCachedQ, transposedA: transposed(.Q), transposedB: transposed(.K),
+      cachePrefix: "cq_"
+    )
+
+    // Mask S at traversal edge (same as forward — zeroes S beyond traversalDim)
+    ir += generateMaskEdge(
+      prefix: "qm_",
+      sSramCount: sSramCount,
+      blockT: blockT, traversalDim: traversalDim,
+      traversalOffset: "%bq_c",
+      regS: regS, scaleFactor: scaleFactor
+    )
+
+    // Step 2: P = exp2(S * scaleFactor - L)
+    // Unlike forward (online softmax), backward uses stored L.
+    ir += generateSoftmaxFromL(
+      prefix: "qs_",
+      sSramCount: sSramCount,
+      regS: regS, regP: regP,
+      scaleFactor: scaleFactor,
+      lScalar: "%L_sram",
+      sSource: "qm_s"  // masked S from generateMaskEdge
+    )
+
+    // Step 3: dP = dO * V^T (outer product)
+    for i in 0..<sSramCount {
+      ir += "  \(irZeroVec64(result: "%dp_init_\(i)", precision: regdP))\n"
+    }
+
+    ir += generateOuterProduct(
+      prefix: "qp_",
+      A: .dO, B: .V, C_name: "dp",
+      sSramCount: sSramCount,
+      blockP: blockP, blockT: blockT, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim, traversalDim: traversalDim,
+      traversalOffset: "%bq_c",
+      regA: regdO, regB: regV, regC: regdP,
+      memA: memdO, memB: memV,
+      leadingDimA: leadingDim(.dO), leadingDimB: leadingDim(.V),
+      leadingBlockDimA: leadingBlockDim(.dO), leadingBlockDimB: leadingBlockDim(.V),
+      cachedA: isCacheddO, transposedA: transposed(.dO), transposedB: transposed(.V),
+      cachePrefix: "cdo_"
+    )
+
+    // Step 4: dS = P * (dP * derivScale - D_sram)
+    ir += generateDerivativeSoftmax(
+      prefix: "qd_",
+      sSramCount: sSramCount,
+      regP: regP, regdP: regdP, regdS: regdS,
+      derivScale: derivScale,
+      dScalar: "%D_sram",
+      pSource: "qs_p",   // from generateSoftmaxFromL with prefix "qs_"
+      dpSource: "dp_final"   // from generateOuterProduct with C_name "dp"
+    )
+
+    // Step 5: dQ += dS * K (accumulate)
+    ir += generateAccumulate(
+      prefix: "qa_",
+      A: .dS, B: .K, C_name: "dq",
+      accCount: dqCount,
+      blockP: blockP, blockT: blockT, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim, traversalDim: traversalDim,
+      traversalOffset: "%bq_c",
+      regA: regdS, regB: regK, regC: regdQ,
+      memB: memK,
+      leadingDimB: leadingDim(.K),
+      leadingBlockDimB: leadingBlockDim(.K),
+      transposedB: transposed(.K),
+      cachedC: isCacheddQ,
+      isFinalScale: false,
+      scaleCorrection: "",
+      aSourcePrefix: "qd_ds"  // from generateDerivativeSoftmax with prefix "qd_"
+    )
+
+    // MARK: - Loop Latch
+
+    ir += "  br label %bq_loop_latch\n"
+    ir += """
+
+    bq_loop_latch:
+
+    """
+
+    for i in 0..<dqCount {
+      ir += "  %dq_acc_\(i) = phi \(irVecType(regdQ)) [%qa_dq_final_\(i), %qa_after_head]\n"
+    }
+
+    ir += """
+
+      %bq_c_next = add i32 %bq_c, \(blockT)
+      br label %bq_loop_header
+
+    """
+
+    // MARK: - Cleanup: store dQ, store D
+
+    ir += generateBackwardQueryCleanup(
+      prefix: "qc_",
+      dqCount: dqCount,
+      blockP: blockP, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim,
+      regdQ: regdQ, memdQ: memdQ,
+      memD: memD,
+      leadingDimdQ: leadingDim(.dQ),
+      leadingBlockDimdQ: leadingBlockDim(.dQ),
+      transposeddQ: transposed(.dQ),
+      cacheddQ: isCacheddQ,
+      derivScale: derivScale
+    )
+
+    return ir
+  }
+
+  // MARK: - Backward Key-Value
+
+  func generateBackwardKeyValueKernel(
+    desc: MonolithicDescriptor,
+    R: UInt32, C: UInt32, D: UInt32,
+    blockP: UInt16, blockT: UInt16, blockH: UInt16,
+    parallelDim: UInt32, traversalDim: UInt32,
+    paddedD: UInt32, headEdge: UInt32,
+    headLoopFloor: UInt32,
+    sSramCount: Int,
+    scaleFactor: Float, tgFloats: Int,
+    leadingDim: (AttentionOperand) -> UInt32,
+    leadingBlockDim: (AttentionOperand) -> UInt32,
+    memPrec: (AttentionOperand) -> GEMMOperandPrecision,
+    regPrec: (AttentionOperand) -> GEMMOperandPrecision,
+    memSize: (AttentionOperand) -> UInt32
+  ) -> String {
+    var ir = ""
+
+    let regS = regPrec(.S)
+    let regP = regPrec(.P)
+    let regdP = regPrec(.dP)
+    let regdS = regPrec(.dS)
+    let regQ = regPrec(.Q)
+    let regK = regPrec(.K)
+    let regV = regPrec(.V)
+    let regdO = regPrec(.dO)
+    let regdK = regPrec(.dK)
+    let regdV = regPrec(.dV)
+    let memQ = memPrec(.Q)
+    let memK = memPrec(.K)
+    let memV = memPrec(.V)
+    let memdO = memPrec(.dO)
+    let memdK = memPrec(.dK)
+    let memdV = memPrec(.dV)
+
+    let isCachedK = cached(.K)
+    let isCachedV = cached(.V)
+    let isCacheddK = cached(.dK)
+    let isCacheddV = cached(.dV)
+
+    let dkCount = Int(paddedD / 8)
+    let dvCount = Int(paddedD / 8)
+
+    let derivScale = 1.0 / Float(headDimension).squareRoot()
+
+    // MARK: - Setup
+
+    ir += "  ; === Backward Key-Value setup ===\n"
+
+    // Cache load K if cached
+    if isCachedK {
+      ir += generateCacheLoad(
+        operand: .K, prefix: "ck_",
+        parallelDim: parallelDim, D: D, paddedD: paddedD,
+        blockP: blockP, blockH: blockH,
+        leadingDim: leadingDim(.K), leadingBlockDim: leadingBlockDim(.K),
+        memPrec: memK, regPrec: regK,
+        transposed: transposed(.K)
+      )
+    }
+
+    // Cache load V if cached
+    if isCachedV {
+      ir += generateCacheLoad(
+        operand: .V, prefix: "cv_",
+        parallelDim: parallelDim, D: D, paddedD: paddedD,
+        blockP: blockP, blockH: blockH,
+        leadingDim: leadingDim(.V), leadingBlockDim: leadingBlockDim(.V),
+        memPrec: memV, regPrec: regV,
+        transposed: transposed(.V)
+      )
+    }
+
+    // Initialize dK and dV accumulators to zero
+    for i in 0..<dkCount {
+      ir += "  \(irZeroVec64(result: "%dk_init_\(i)", precision: regdK))\n"
+    }
+    for i in 0..<dvCount {
+      ir += "  \(irZeroVec64(result: "%dv_init_\(i)", precision: regdV))\n"
+    }
+
+    // MARK: - Traversal Loop
+
+    ir += """
+
+      ; === Traversal loop ===
+      br label %bkv_before_loop
+    bkv_before_loop:
+      br label %bkv_loop_header
+
+    bkv_loop_header:
+      %bkv_r = phi i32 [0, %bkv_before_loop], [%bkv_r_next, %bkv_loop_latch]
+
+    """
+
+    // Phi nodes for dK and dV accumulators
+    for i in 0..<dkCount {
+      ir += "  %dk_phi_\(i) = phi \(irVecType(regdK)) [%dk_init_\(i), %bkv_before_loop], [%dk_acc_\(i), %bkv_loop_latch]\n"
+    }
+    for i in 0..<dvCount {
+      ir += "  %dv_phi_\(i) = phi \(irVecType(regdV)) [%dv_init_\(i), %bkv_before_loop], [%dv_acc_\(i), %bkv_loop_latch]\n"
+    }
+
+    ir += """
+
+      %bkv_loop_done = icmp uge i32 %bkv_r, \(traversalDim)
+      br i1 %bkv_loop_done, label %bkv_cleanup, label %bkv_loop_body
+
+    bkv_loop_body:
+
+    """
+
+    // L and D are per-row scalars that vary per-column of S^T (each column
+    // = different traversal row). They are loaded per-tile inside
+    // generateSoftmaxFromLVector and generateDerivativeSoftmaxVector
+    // respectively, not once per traversal block.
+
+    // Step 1: S^T = K * Q^T (outer product)
+    for i in 0..<sSramCount {
+      ir += "  \(irZeroVec64(result: "%s_init_\(i)", precision: regS))\n"
+    }
+
+    ir += generateOuterProduct(
+      prefix: "ko_",
+      A: .K, B: .Q, C_name: "s",
+      sSramCount: sSramCount,
+      blockP: blockP, blockT: blockT, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim, traversalDim: traversalDim,
+      traversalOffset: "%bkv_r",
+      regA: regK, regB: regQ, regC: regS,
+      memA: memK, memB: memQ,
+      leadingDimA: leadingDim(.K), leadingDimB: leadingDim(.Q),
+      leadingBlockDimA: leadingBlockDim(.K), leadingBlockDimB: leadingBlockDim(.Q),
+      cachedA: isCachedK, transposedA: transposed(.K), transposedB: transposed(.Q),
+      cachePrefix: "ck_"
+    )
+
+    // Mask S^T at traversal edge
+    ir += generateMaskEdge(
+      prefix: "km_",
+      sSramCount: sSramCount,
+      blockT: blockT, traversalDim: traversalDim,
+      traversalOffset: "%bkv_r",
+      regS: regS, scaleFactor: scaleFactor
+    )
+
+    // Step 2: P^T = exp2(S^T * scaleFactor - L)
+    // L varies per-column of S^T (each column = different traversal row),
+    // so it must be loaded per-tile from the L buffer.
+    ir += generateSoftmaxFromLVector(
+      prefix: "ks_",
+      sSramCount: sSramCount,
+      regS: regS, regP: regP,
+      scaleFactor: scaleFactor,
+      lBufferName: "%L_buf",
+      traversalOffset: "%bkv_r",
+      traversalDim: traversalDim,
+      memL: memPrec(.L),
+      sSource: "km_s"  // masked S from generateMaskEdge
+    )
+
+    // Step 3: dV += P^T * dO (accumulate)
+    ir += generateAccumulate(
+      prefix: "kv_",
+      A: .P, B: .dO, C_name: "dv",
+      accCount: dvCount,
+      blockP: blockP, blockT: blockT, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim, traversalDim: traversalDim,
+      traversalOffset: "%bkv_r",
+      regA: regP, regB: regdO, regC: regdV,
+      memB: memdO,
+      leadingDimB: leadingDim(.dO),
+      leadingBlockDimB: leadingBlockDim(.dO),
+      transposedB: transposed(.dO),
+      cachedC: isCacheddV,
+      isFinalScale: false,
+      scaleCorrection: "",
+      aSourcePrefix: "ks_p"  // from generateSoftmaxFromLVector with prefix "ks_"
+    )
+
+    // Step 4: dP^T = V * dO^T (outer product)
+    for i in 0..<sSramCount {
+      ir += "  \(irZeroVec64(result: "%dp_init_\(i)", precision: regdP))\n"
+    }
+
+    ir += generateOuterProduct(
+      prefix: "kp_",
+      A: .V, B: .dO, C_name: "dp",
+      sSramCount: sSramCount,
+      blockP: blockP, blockT: blockT, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim, traversalDim: traversalDim,
+      traversalOffset: "%bkv_r",
+      regA: regV, regB: regdO, regC: regdP,
+      memA: memV, memB: memdO,
+      leadingDimA: leadingDim(.V), leadingDimB: leadingDim(.dO),
+      leadingBlockDimA: leadingBlockDim(.V), leadingBlockDimB: leadingBlockDim(.dO),
+      cachedA: isCachedV, transposedA: transposed(.V), transposedB: transposed(.dO),
+      cachePrefix: "cv_"
+    )
+
+    // Step 5: dS^T = P^T * (dP^T * derivScale - D_stored)
+    // D_stored is pre-scaled (D_raw * derivScale) from bwd_q kernel.
+    // D varies per-column of S^T (each column = different traversal row),
+    // so it must be loaded per-tile, not once per traversal block.
+    ir += generateDerivativeSoftmaxVector(
+      prefix: "kd_",
+      sSramCount: sSramCount,
+      regP: regP, regdP: regdP, regdS: regdS,
+      derivScale: derivScale,
+      dBufferName: "%D_buf",
+      traversalOffset: "%bkv_r",
+      traversalDim: traversalDim,
+      memD: memPrec(.D),
+      pSource: "ks_p",   // from generateSoftmaxFromLVector with prefix "ks_"
+      dpSource: "dp_final"    // from generateOuterProduct with C_name "dp"
+    )
+
+    // Step 6: dK += dS^T * Q (accumulate)
+    ir += generateAccumulate(
+      prefix: "kk_",
+      A: .dS, B: .Q, C_name: "dk",
+      accCount: dkCount,
+      blockP: blockP, blockT: blockT, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim, traversalDim: traversalDim,
+      traversalOffset: "%bkv_r",
+      regA: regdS, regB: regQ, regC: regdK,
+      memB: memQ,
+      leadingDimB: leadingDim(.Q),
+      leadingBlockDimB: leadingBlockDim(.Q),
+      transposedB: transposed(.Q),
+      cachedC: isCacheddK,
+      isFinalScale: false,
+      scaleCorrection: "",
+      aSourcePrefix: "kd_ds"  // from generateDerivativeSoftmaxVector with prefix "kd_"
+    )
+
+    // MARK: - Loop Latch
+
+    ir += "  br label %bkv_loop_latch\n"
+    ir += """
+
+    bkv_loop_latch:
+
+    """
+
+    for i in 0..<dkCount {
+      ir += "  %dk_acc_\(i) = phi \(irVecType(regdK)) [%kk_dk_final_\(i), %kk_after_head]\n"
+    }
+    for i in 0..<dvCount {
+      ir += "  %dv_acc_\(i) = phi \(irVecType(regdV)) [%kv_dv_final_\(i), %kk_after_head]\n"
+    }
+
+    ir += """
+
+      %bkv_r_next = add i32 %bkv_r, \(blockT)
+      br label %bkv_loop_header
+
+    """
+
+    // MARK: - Cleanup: store dK, store dV
+
+    ir += generateBackwardKeyValueCleanup(
+      prefix: "kc_",
+      dkCount: dkCount, dvCount: dvCount,
+      blockP: blockP, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim,
+      regdK: regdK, memdK: memdK,
+      regdV: regdV, memdV: memdV,
+      leadingDimdK: leadingDim(.dK),
+      leadingBlockDimdK: leadingBlockDim(.dK),
+      leadingDimdV: leadingDim(.dV),
+      leadingBlockDimdV: leadingBlockDim(.dV),
+      transposeddK: transposed(.dK),
+      transposeddV: transposed(.dV),
+      cacheddK: isCacheddK,
+      cacheddV: isCacheddV
+    )
+
+    return ir
+  }
+}

--- a/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+ForwardIR.swift
+++ b/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+ForwardIR.swift
@@ -1,0 +1,323 @@
+//
+//  AttentionKernel+ForwardIR.swift
+//  FlashAttention
+//
+//  Forward attention kernel IR generation.
+//  S = Q * K^T, softmax, O += P * V, O /= l, store L.
+//
+//  Double-buffered: K uses TG slot A (offset 0), V uses TG slot B (offset slotSize).
+//  V[d_outer=0] copy overlaps with S = Q*K^T computation.
+//  K[i+1, d_outer=0] copy overlaps with O += P*V computation.
+//
+
+extension AttentionKernel {
+
+  func generateForwardKernel(
+    desc: MonolithicDescriptor,
+    R: UInt32, C: UInt32, D: UInt32,
+    blockP: UInt16, blockT: UInt16, blockH: UInt16,
+    parallelDim: UInt32, traversalDim: UInt32,
+    paddedD: UInt32, headEdge: UInt32,
+    headLoopFloor: UInt32,
+    oCachedCount: Int, sSramCount: Int,
+    scaleFactor: Float, tgFloats: Int,
+    leadingDim: (AttentionOperand) -> UInt32,
+    leadingBlockDim: (AttentionOperand) -> UInt32,
+    memPrec: (AttentionOperand) -> GEMMOperandPrecision,
+    regPrec: (AttentionOperand) -> GEMMOperandPrecision,
+    memSize: (AttentionOperand) -> UInt32
+  ) -> String {
+    var ir = ""
+
+    let regS = regPrec(.S)
+    let regP = regPrec(.P)
+    let regO = regPrec(.O)
+    let regQ = regPrec(.Q)
+    let regK = regPrec(.K)
+    let regV = regPrec(.V)
+    let memQ = memPrec(.Q)
+    let memK = memPrec(.K)
+    let memV = memPrec(.V)
+    let memO = memPrec(.O)
+    let memL = memPrec(.L)
+
+    let isCachedQ = cached(.Q)
+    let isCachedO = cached(.O)
+
+    // TG slot offsets for double-buffering
+    let slotSize = Int(forwardTGSlotSize)
+    let slotA = "0"           // K slot
+    let slotB = "\(slotSize)" // V slot
+
+    // First head block size for prefetch
+    let firstBlockHead = min(UInt16(D), blockH)
+
+    // MARK: - Setup
+
+    // Initialize O accumulators to zero
+    ir += "  ; === Forward setup ===\n"
+    for i in 0..<oCachedCount {
+      ir += "  \(irZeroVec64(result: "%o_init_\(i)", precision: regO))\n"
+    }
+    ir += "  ; m = -MAX, l = denorm_min\n"
+    ir += "  %m_init = bitcast float 0xFFF0000000000000 to float ; -inf\n"
+    // denorm_min ≈ 1.4e-45
+    ir += "  %l_init = bitcast float 0x36A0000000000000 to float ; denorm_min\n"
+
+    // Cache load Q if cached
+    if isCachedQ {
+      ir += generateCacheLoad(
+        operand: .Q, prefix: "cq_",
+        parallelDim: parallelDim, D: D, paddedD: paddedD,
+        blockP: blockP, blockH: blockH,
+        leadingDim: leadingDim(.Q), leadingBlockDim: leadingBlockDim(.Q),
+        memPrec: memQ, regPrec: regQ,
+        transposed: transposed(.Q)
+      )
+    }
+
+    // MARK: - Prologue: Prefetch K[0, d_outer=0] → TG slot A
+
+    ir += "  ; === Prologue: prefetch K[0, d_outer=0] → TG slot A ===\n"
+    ir += generateAsyncCopyDeviceToTG(
+      prefix: "pre_k_",
+      buffer: "%K",
+      operand: .K,
+      dOuter: "0",
+      seqOffset: "0",
+      seqDim: traversalDim,
+      blockSeq: blockT,
+      blockHead: firstBlockHead,
+      D: D,
+      leadingDim: leadingDim(.K),
+      leadingBlockDim: leadingBlockDim(.K),
+      memPrec: memK,
+      transposed: transposed(.K),
+      tgOffset: slotA
+    )
+
+    // MARK: - Traversal Loop
+
+    ir += """
+
+      ; === Traversal loop (double-buffered) ===
+      br label %before_loop
+    before_loop:
+      br label %loop_header
+
+    loop_header:
+      %c = phi i32 [0, %before_loop], [%c_next, %loop_latch]
+      %m_phi = phi float [%m_init, %before_loop], [%m_updated, %loop_latch]
+      %l_phi = phi float [%l_init, %before_loop], [%l_updated, %loop_latch]
+
+    """
+
+    // Phi nodes for O accumulators
+    for i in 0..<oCachedCount {
+      ir += "  %o_phi_\(i) = phi \(irVecType(regO)) [%o_init_\(i), %before_loop], [%o_acc_\(i), %loop_latch]\n"
+    }
+
+    ir += """
+
+      %loop_done = icmp uge i32 %c, \(traversalDim)
+      br i1 %loop_done, label %cleanup, label %loop_body
+
+    loop_body:
+
+    """
+
+    // MARK: - Start V[c, d_outer=0] copy → TG slot B (overlaps with S compute)
+
+    ir += "  ; === Start V[c, d_outer=0] → TG slot B (no wait) ===\n"
+    ir += generateAsyncCopyStart(
+      prefix: "pv_",
+      buffer: "%V",
+      operand: .V,
+      dOuter: "0",
+      seqOffset: "%c",
+      seqDim: traversalDim,
+      blockSeq: blockT,
+      blockHead: firstBlockHead,
+      D: D,
+      leadingDim: leadingDim(.V),
+      leadingBlockDim: leadingBlockDim(.V),
+      memPrec: memV,
+      transposed: transposed(.V),
+      tgOffset: slotB,
+      eventSlot: 1
+    )
+
+    // MARK: - Outer Product (S = Q * K^T) — K already in TG slot A
+
+    // Initialize S accumulators to zero
+    for i in 0..<sSramCount {
+      ir += "  \(irZeroVec64(result: "%s_init_\(i)", precision: regS))\n"
+    }
+
+    // K[c, d_outer=0] is already in TG slot A (from prologue or previous iter's prefetch).
+    // skipFirstIterCopy=true: first d_outer iteration skips async copy.
+    // Subsequent d_outer iterations still do their own copies to slot A.
+    ir += generateOuterProduct(
+      prefix: "op_",
+      A: .Q, B: .K, C_name: "s",
+      sSramCount: sSramCount,
+      blockP: blockP, blockT: blockT, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim, traversalDim: traversalDim,
+      traversalOffset: "%c",
+      regA: regQ, regB: regK, regC: regS,
+      memA: memQ, memB: memK,
+      leadingDimA: leadingDim(.Q), leadingDimB: leadingDim(.K),
+      leadingBlockDimA: leadingBlockDim(.Q), leadingBlockDimB: leadingBlockDim(.K),
+      cachedA: isCachedQ, transposedA: transposed(.Q), transposedB: transposed(.K),
+      tgOffset: slotA,
+      skipFirstIterCopy: true
+    )
+
+    // MARK: - Wait for V copy to complete
+
+    ir += "  ; === Wait for V[c, d_outer=0] copy ===\n"
+    ir += generateAsyncCopyWait(prefix: "wv_", eventSlot: 1)
+
+    // MARK: - Mask Attention Matrix Edge
+
+    ir += generateMaskEdge(
+      prefix: "mask_",
+      sSramCount: sSramCount,
+      blockT: blockT, traversalDim: traversalDim,
+      traversalOffset: "%c",
+      regS: regS, scaleFactor: scaleFactor
+    )
+
+    // MARK: - Online Softmax: Reduce Maximum
+
+    ir += generateReduceMax(
+      prefix: "rmax_",
+      sSramCount: sSramCount,
+      regS: regS, scaleFactor: scaleFactor
+    )
+
+    // MARK: - Online Softmax: Correct O
+
+    ir += generateCorrectO(
+      prefix: "corr_",
+      oCachedCount: oCachedCount,
+      regO: regO
+    )
+
+    // MARK: - Online Softmax: Compute P = exp2(S * scale - m)
+
+    ir += generateComputeP(
+      prefix: "sp_",
+      sSramCount: sSramCount,
+      regS: regS, regP: regP,
+      scaleFactor: scaleFactor
+    )
+
+    // MARK: - Online Softmax: Reduce Sum
+
+    ir += generateReduceSum(
+      prefix: "rsum_",
+      sSramCount: sSramCount,
+      regP: regP
+    )
+
+    // MARK: - Accumulate O += P * V — V already in TG slot B
+
+    // V[c, d_outer=0] is already in TG slot B (waited above).
+    // skipFirstIterCopy=true: first d_outer iteration skips async copy.
+    // Subsequent d_outer iterations still do their own copies to slot B.
+    ir += generateAccumulate(
+      prefix: "acc_",
+      A: .P, B: .V, C_name: "o",
+      accCount: oCachedCount,
+      blockP: blockP, blockT: blockT, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim, traversalDim: traversalDim,
+      traversalOffset: "%c",
+      regA: regP, regB: regV, regC: regO,
+      memB: memPrec(.V),
+      leadingDimB: leadingDim(.V),
+      leadingBlockDimB: leadingBlockDim(.V),
+      transposedB: transposed(.V),
+      cachedC: isCachedO,
+      isFinalScale: false,
+      scaleCorrection: "corr_correction",
+      tgOffset: slotB,
+      skipFirstIterCopy: true
+    )
+
+    // MARK: - Prefetch K[c+blockT, d_outer=0] → TG slot A (overlaps with loop overhead)
+
+    // Use zero-height trick on last iteration to avoid conditional branches.
+    // When c+blockT >= C, the seq dimension remaining is 0, so async_copy is a no-op.
+    ir += """
+
+      ; === Prefetch K[c+blockT, d_outer=0] → TG slot A ===
+      %c_next = add i32 %c, \(blockT)
+
+    """
+
+    ir += generateAsyncCopyStart(
+      prefix: "pk_",
+      buffer: "%K",
+      operand: .K,
+      dOuter: "0",
+      seqOffset: "%c_next",
+      seqDim: traversalDim,
+      blockSeq: blockT,
+      blockHead: firstBlockHead,
+      D: D,
+      leadingDim: leadingDim(.K),
+      leadingBlockDim: leadingBlockDim(.K),
+      memPrec: memK,
+      transposed: transposed(.K),
+      tgOffset: slotA,
+      eventSlot: 0
+    )
+
+    // Wait for K prefetch before next iteration reads from TG slot A
+    ir += generateAsyncCopyWait(prefix: "wk_", eventSlot: 0)
+
+    // MARK: - Loop Latch
+
+    ir += "  br label %loop_latch\n"
+    ir += """
+
+    loop_latch:
+      %m_updated = phi float [%corr_m_upd, %wk_after_wait]
+      %l_updated = phi float [%rsum_l_new, %wk_after_wait]
+
+    """
+
+    for i in 0..<oCachedCount {
+      ir += "  %o_acc_\(i) = phi \(irVecType(regO)) [%acc_o_final_\(i), %wk_after_wait]\n"
+    }
+
+    ir += """
+
+      br label %loop_header
+
+    """
+
+    // MARK: - Cleanup: O /= l, store O, store L
+
+    ir += generateForwardCleanup(
+      prefix: "cl_",
+      oCachedCount: oCachedCount,
+      blockP: blockP, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim,
+      regO: regO, memO: memO, memL: memL,
+      leadingDimO: leadingDim(.O),
+      leadingBlockDimO: leadingBlockDim(.O),
+      transposedO: transposed(.O),
+      cachedO: isCachedO
+    )
+
+    return ir
+  }
+}

--- a/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+IRHelpers.swift
+++ b/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+IRHelpers.swift
@@ -1,0 +1,2303 @@
+//
+//  AttentionKernel+IRHelpers.swift
+//  FlashAttention
+//
+//  Shared IR generation helpers for attention monolithic kernels.
+//  These generate the building blocks: async copy, outer product,
+//  softmax, accumulate, cache load/store.
+//
+
+extension AttentionKernel {
+
+  // MARK: - Async Copy Device → TG (2D)
+
+  /// Generate an inline async copy START (no wait). Gated to sidx == 0.
+  /// Returns IR that ends after the copy is initiated but NOT waited on.
+  /// Use generateAsyncCopyWait to wait + barrier later.
+  func generateAsyncCopyStart(
+    prefix p: String,
+    buffer: String,
+    operand: AttentionOperand,
+    dOuter: String,
+    seqOffset: String,
+    seqDim: UInt32,
+    blockSeq: UInt16,
+    blockHead: UInt16,
+    D: UInt32,
+    leadingDim: UInt32,
+    leadingBlockDim: UInt32,
+    memPrec: GEMMOperandPrecision,
+    transposed: Bool,
+    tgOffset: String = "0",
+    eventSlot: Int = 0
+  ) -> String {
+    let elemSize = UInt32(memPrec.size)
+    var ir = ""
+
+    ir += "  ; Async copy START \(operand) device→TG (\(p))\n"
+    ir += "  br i1 %is_sidx0, label %\(p)do_copy, label %\(p)skip_copy\n\n"
+    ir += "\(p)do_copy:\n"
+
+    // Source offset calculation
+    if transposed {
+      ir += "  %\(p)src_row = mul i32 \(dOuter), \(leadingDim)\n"
+      ir += "  %\(p)src_off32 = add i32 %\(p)src_row, \(seqOffset)\n"
+    } else {
+      ir += "  %\(p)src_row = mul i32 \(seqOffset), \(leadingDim)\n"
+      ir += "  %\(p)src_off32 = add i32 %\(p)src_row, \(dOuter)\n"
+    }
+    ir += "  %\(p)src_off = zext i32 %\(p)src_off32 to i64\n"
+    ir += "  %\(p)src_byte = mul i64 %\(p)src_off, \(elemSize)\n"
+    ir += "  %\(p)src_p = getelementptr i8, i8 addrspace(1)* \(buffer), i64 %\(p)src_byte\n"
+
+    ir += "  %\(p)d_rem_32 = sub i32 \(D), \(dOuter)\n"
+    ir += "  %\(p)d_cmp = icmp ult i32 %\(p)d_rem_32, \(blockHead)\n"
+    ir += "  %\(p)d_src = select i1 %\(p)d_cmp, i32 %\(p)d_rem_32, i32 \(blockHead)\n"
+    // Guard: if seqOffset >= seqDim, zero-height copy (no-op).
+    ir += "  %\(p)seq_oob = icmp uge i32 \(seqOffset), \(seqDim)\n"
+    ir += "  %\(p)seq_rem_raw = sub i32 \(seqDim), \(seqOffset)\n"
+    ir += "  %\(p)seq_rem_32 = select i1 %\(p)seq_oob, i32 0, i32 %\(p)seq_rem_raw\n"
+    ir += "  %\(p)seq_cmp = icmp ult i32 %\(p)seq_rem_32, \(blockSeq)\n"
+    ir += "  %\(p)seq_src = select i1 %\(p)seq_cmp, i32 %\(p)seq_rem_32, i32 \(blockSeq)\n"
+
+    let dstStride = leadingBlockDim * elemSize
+    let srcStride = leadingDim * elemSize
+
+    let (srcW, srcH, dstW, dstH): (String, String, UInt32, UInt32)
+    if transposed {
+      srcW = "%\(p)seq_src_bytes"
+      srcH = "%\(p)d_src_ext"
+      ir += "  %\(p)seq_src_bytes32 = mul i32 %\(p)seq_src, \(elemSize)\n"
+      ir += "  %\(p)seq_src_bytes = zext i32 %\(p)seq_src_bytes32 to i64\n"
+      ir += "  %\(p)d_src_ext = zext i32 %\(p)d_src to i64\n"
+      dstW = UInt32(blockSeq) * elemSize
+      dstH = UInt32(blockHead)
+    } else {
+      srcW = "%\(p)d_src_bytes"
+      srcH = "%\(p)seq_src_ext"
+      ir += "  %\(p)d_src_bytes32 = mul i32 %\(p)d_src, \(elemSize)\n"
+      ir += "  %\(p)d_src_bytes = zext i32 %\(p)d_src_bytes32 to i64\n"
+      ir += "  %\(p)seq_src_ext = zext i32 %\(p)seq_src to i64\n"
+      dstW = UInt32(blockHead) * elemSize
+      dstH = UInt32(blockSeq)
+    }
+
+    // TG destination pointer
+    ir += "  %\(p)dst_p = getelementptr i8, i8 addrspace(3)* %tg_base, i64 \(tgOffset)\n"
+
+    // Tile vectors
+    ir += "  %\(p)stile_w = insertelement <2 x i64> zeroinitializer, i64 \(srcW), i32 0\n"
+    ir += "  %\(p)stile = insertelement <2 x i64> %\(p)stile_w, i64 \(srcH), i32 1\n"
+    ir += "  %\(p)dtile_w = insertelement <2 x i64> zeroinitializer, i64 \(dstW), i32 0\n"
+    ir += "  %\(p)dtile = insertelement <2 x i64> %\(p)dtile_w, i64 \(dstH), i32 1\n"
+
+    // Event pointer (use specified slot)
+    ir += "  %\(p)evp = getelementptr [2 x %event_t addrspace(3)*], [2 x %event_t addrspace(3)*]* %ev, i64 0, i64 \(eventSlot)\n"
+
+    // Async copy call — NO wait
+    ir += """
+      %\(p)ev = call %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p3i8.p1i8(
+        i64 1, i64 1,
+        i8 addrspace(3)* %\(p)dst_p, i64 \(dstStride), i64 1, <2 x i64> %\(p)dtile,
+        i8 addrspace(1)* %\(p)src_p, i64 \(srcStride), i64 1, <2 x i64> %\(p)stile,
+        <2 x i64> zeroinitializer, i32 0
+      )
+      store %event_t addrspace(3)* %\(p)ev, %event_t addrspace(3)** %\(p)evp
+
+    """
+
+    ir += "  br label %\(p)after_copy\n\n"
+    ir += "\(p)skip_copy:\n"
+    ir += "  br label %\(p)after_copy\n\n"
+    ir += "\(p)after_copy:\n"
+    // Barrier so all threads sync after sidx0 initiated the copy
+    ir += "  call void @air.wg.barrier(i32 2, i32 1)\n\n"
+
+    return ir
+  }
+
+  /// Wait for a previously started async copy + barrier for TG visibility.
+  func generateAsyncCopyWait(
+    prefix p: String,
+    eventSlot: Int = 0
+  ) -> String {
+    var ir = ""
+    ir += "  ; Wait for async copy (\(p))\n"
+    ir += "  br i1 %is_sidx0, label %\(p)do_wait, label %\(p)skip_wait\n\n"
+    ir += "\(p)do_wait:\n"
+    ir += "  %\(p)evp = getelementptr [2 x %event_t addrspace(3)*], [2 x %event_t addrspace(3)*]* %ev, i64 0, i64 \(eventSlot)\n"
+    ir += "  call void @air.wait_simdgroup_events(i32 1, %event_t addrspace(3)** %\(p)evp)\n"
+    ir += "  br label %\(p)after_wait\n\n"
+    ir += "\(p)skip_wait:\n"
+    ir += "  br label %\(p)after_wait\n\n"
+    ir += "\(p)after_wait:\n"
+    ir += "  call void @air.wg.barrier(i32 2, i32 1)\n\n"
+    return ir
+  }
+
+  /// Generate an inline async copy from device to threadgroup.
+  /// Gated to sidx == 0. Returns IR that ends after barrier.
+  func generateAsyncCopyDeviceToTG(
+    prefix p: String,
+    buffer: String,           // SSA name of device buffer (e.g. "%K")
+    operand: AttentionOperand,
+    dOuter: String,           // SSA name or literal for d_outer offset
+    seqOffset: String,        // SSA name or literal for sequence offset
+    seqDim: UInt32,           // total sequence dimension
+    blockSeq: UInt16,         // block size along sequence dim
+    blockHead: UInt16,        // block size along head dim (register size for this iteration)
+    D: UInt32,                // total head dimension
+    leadingDim: UInt32,
+    leadingBlockDim: UInt32,
+    memPrec: GEMMOperandPrecision,
+    transposed: Bool,
+    tgOffset: String = "0"    // byte offset into TG buffer
+  ) -> String {
+    let elemSize = UInt32(memPrec.size)
+    var ir = ""
+
+    ir += "  ; Async copy \(operand) device→TG (\(p))\n"
+    ir += "  br i1 %is_sidx0, label %\(p)do_copy, label %\(p)skip_copy\n\n"
+    ir += "\(p)do_copy:\n"
+
+    // Source offset calculation
+    if transposed {
+      // offset = (dOuter) * leadingDim + seqOffset
+      ir += "  %\(p)src_row = mul i32 \(dOuter), \(leadingDim)\n"
+      ir += "  %\(p)src_off32 = add i32 %\(p)src_row, \(seqOffset)\n"
+    } else {
+      // offset = seqOffset * leadingDim + dOuter
+      ir += "  %\(p)src_row = mul i32 \(seqOffset), \(leadingDim)\n"
+      ir += "  %\(p)src_off32 = add i32 %\(p)src_row, \(dOuter)\n"
+    }
+    ir += "  %\(p)src_off = zext i32 %\(p)src_off32 to i64\n"
+    ir += "  %\(p)src_byte = mul i64 %\(p)src_off, \(elemSize)\n"
+    ir += "  %\(p)src_p = getelementptr i8, i8 addrspace(1)* \(buffer), i64 %\(p)src_byte\n"
+
+    // D source tile = min(blockHead, D - dOuter)
+    // Seq source tile = min(blockSeq, seqDim - seqOffset)
+    ir += "  %\(p)d_rem_32 = sub i32 \(D), \(dOuter)\n"
+    ir += "  %\(p)d_cmp = icmp ult i32 %\(p)d_rem_32, \(blockHead)\n"
+    ir += "  %\(p)d_src = select i1 %\(p)d_cmp, i32 %\(p)d_rem_32, i32 \(blockHead)\n"
+    ir += "  %\(p)seq_rem_32 = sub i32 \(seqDim), \(seqOffset)\n"
+    ir += "  %\(p)seq_cmp = icmp ult i32 %\(p)seq_rem_32, \(blockSeq)\n"
+    ir += "  %\(p)seq_src = select i1 %\(p)seq_cmp, i32 %\(p)seq_rem_32, i32 \(blockSeq)\n"
+
+    let dstStride = leadingBlockDim * elemSize
+    let srcStride = leadingDim * elemSize
+
+    // Build tile vectors. The tile is (width_bytes, height).
+    // For non-transposed: width = D elements, height = seq elements
+    // For transposed: width = seq elements, height = D elements
+    let (srcW, srcH, dstW, dstH): (String, String, UInt32, UInt32)
+    if transposed {
+      srcW = "%\(p)seq_src_bytes"
+      srcH = "%\(p)d_src_ext"
+      ir += "  %\(p)seq_src_bytes32 = mul i32 %\(p)seq_src, \(elemSize)\n"
+      ir += "  %\(p)seq_src_bytes = zext i32 %\(p)seq_src_bytes32 to i64\n"
+      ir += "  %\(p)d_src_ext = zext i32 %\(p)d_src to i64\n"
+      dstW = UInt32(blockSeq) * elemSize
+      dstH = UInt32(blockHead)
+    } else {
+      srcW = "%\(p)d_src_bytes"
+      srcH = "%\(p)seq_src_ext"
+      ir += "  %\(p)d_src_bytes32 = mul i32 %\(p)d_src, \(elemSize)\n"
+      ir += "  %\(p)d_src_bytes = zext i32 %\(p)d_src_bytes32 to i64\n"
+      ir += "  %\(p)seq_src_ext = zext i32 %\(p)seq_src to i64\n"
+      dstW = UInt32(blockHead) * elemSize
+      dstH = UInt32(blockSeq)
+    }
+
+    // TG destination pointer
+    ir += "  %\(p)dst_p = getelementptr i8, i8 addrspace(3)* %tg_base, i64 \(tgOffset)\n"
+
+    // Tile vectors
+    ir += "  %\(p)stile_w = insertelement <2 x i64> zeroinitializer, i64 \(srcW), i32 0\n"
+    ir += "  %\(p)stile = insertelement <2 x i64> %\(p)stile_w, i64 \(srcH), i32 1\n"
+    ir += "  %\(p)dtile_w = insertelement <2 x i64> zeroinitializer, i64 \(dstW), i32 0\n"
+    ir += "  %\(p)dtile = insertelement <2 x i64> %\(p)dtile_w, i64 \(dstH), i32 1\n"
+
+    // Event pointer
+    ir += "  %\(p)evp = getelementptr [2 x %event_t addrspace(3)*], [2 x %event_t addrspace(3)*]* %ev, i64 0, i64 0\n"
+
+    // Async copy call
+    ir += """
+      %\(p)ev = call %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p3i8.p1i8(
+        i64 1, i64 1,
+        i8 addrspace(3)* %\(p)dst_p, i64 \(dstStride), i64 1, <2 x i64> %\(p)dtile,
+        i8 addrspace(1)* %\(p)src_p, i64 \(srcStride), i64 1, <2 x i64> %\(p)stile,
+        <2 x i64> zeroinitializer, i32 0
+      )
+      store %event_t addrspace(3)* %\(p)ev, %event_t addrspace(3)** %\(p)evp
+      call void @air.wait_simdgroup_events(i32 1, %event_t addrspace(3)** %\(p)evp)
+
+    """
+
+    ir += "  br label %\(p)after_copy\n\n"
+    ir += "\(p)skip_copy:\n"
+    ir += "  br label %\(p)after_copy\n\n"
+    ir += "\(p)after_copy:\n"
+    ir += "  call void @air.wg.barrier(i32 2, i32 1)\n\n"
+
+    return ir
+  }
+
+  // MARK: - Load from TG into Register (SIMD matrix)
+
+  /// Generate IR to load a <2 x T> from threadgroup memory, convert precision,
+  /// and expand to <64 x T> via insertelement.
+  func generateTGLoad(
+    prefix p: String,
+    tgOffset: String,         // byte offset into TG (literal or SSA)
+    rowOffset: String,        // row offset (SSA)
+    colOffset: String,        // column offset (SSA)
+    leadingBlockDim: UInt32,
+    memPrec: GEMMOperandPrecision,
+    regPrec: GEMMOperandPrecision,
+    transposed: Bool
+  ) -> String {
+    let elemSize = UInt32(memPrec.size)
+    let memType = irTypeName(memPrec)
+    let regType = irTypeName(regPrec)
+    var ir = ""
+
+    // Address: tg_base + tgOffset + (row * leadingBlockDim + col) * elemSize
+    // For non-transposed: row = seqOffset, col = headOffset (standard matrix layout)
+    // The caller sets rowOffset/colOffset appropriately for the transpose state.
+    let tgOffsetI64 = (tgOffset == "0") ? nil : tgOffset
+    if transposed {
+      // Element address: each thread reads 2 elements (via morton_x offsets)
+      // For transposed, row=morton_x+d, col=oig_y or similar
+      for elem in 0..<2 {
+        ir += "  %\(p)r_\(elem) = add i32 \(rowOffset), \(elem)\n"
+        ir += "  %\(p)addr_\(elem) = mul i32 %\(p)r_\(elem), \(leadingBlockDim)\n"
+        ir += "  %\(p)addr2_\(elem) = add i32 %\(p)addr_\(elem), \(colOffset)\n"
+        ir += "  %\(p)byte_\(elem) = mul i32 %\(p)addr2_\(elem), \(elemSize)\n"
+        ir += "  %\(p)byte64_\(elem) = zext i32 %\(p)byte_\(elem) to i64\n"
+        if let off = tgOffsetI64 {
+          ir += "  %\(p)byte64o_\(elem) = add i64 %\(p)byte64_\(elem), \(off)\n"
+          ir += "  %\(p)ptr_\(elem) = getelementptr i8, i8 addrspace(3)* %tg_base, i64 %\(p)byte64o_\(elem)\n"
+        } else {
+          ir += "  %\(p)ptr_\(elem) = getelementptr i8, i8 addrspace(3)* %tg_base, i64 %\(p)byte64_\(elem)\n"
+        }
+        ir += "  %\(p)typed_\(elem) = bitcast i8 addrspace(3)* %\(p)ptr_\(elem) to \(memType) addrspace(3)*\n"
+        ir += "  %\(p)load_\(elem) = load \(memType), \(memType) addrspace(3)* %\(p)typed_\(elem)\n"
+      }
+      if memPrec != regPrec {
+        for elem in 0..<2 {
+          ir += "  %\(p)ext_\(elem) = fpext \(memType) %\(p)load_\(elem) to \(regType)\n"
+        }
+        ir += "  %\(p)v2_a = insertelement <2 x \(regType)> undef, \(regType) %\(p)ext_0, i32 0\n"
+        ir += "  %\(p)v2 = insertelement <2 x \(regType)> %\(p)v2_a, \(regType) %\(p)ext_1, i32 1\n"
+      } else {
+        ir += "  %\(p)v2_a = insertelement <2 x \(memType)> undef, \(memType) %\(p)load_0, i32 0\n"
+        ir += "  %\(p)v2 = insertelement <2 x \(memType)> %\(p)v2_a, \(memType) %\(p)load_1, i32 1\n"
+      }
+    } else {
+      // Non-transposed: load contiguous <2 x T>
+      ir += "  %\(p)addr = mul i32 \(rowOffset), \(leadingBlockDim)\n"
+      ir += "  %\(p)addr2 = add i32 %\(p)addr, \(colOffset)\n"
+      ir += "  %\(p)byte = mul i32 %\(p)addr2, \(elemSize)\n"
+      ir += "  %\(p)byte64 = zext i32 %\(p)byte to i64\n"
+      if let off = tgOffsetI64 {
+        ir += "  %\(p)byte64o = add i64 %\(p)byte64, \(off)\n"
+        ir += "  %\(p)ptr = getelementptr i8, i8 addrspace(3)* %tg_base, i64 %\(p)byte64o\n"
+      } else {
+        ir += "  %\(p)ptr = getelementptr i8, i8 addrspace(3)* %tg_base, i64 %\(p)byte64\n"
+      }
+      ir += "  %\(p)typed = bitcast i8 addrspace(3)* %\(p)ptr to <2 x \(memType)> addrspace(3)*\n"
+      ir += "  %\(p)load = load <2 x \(memType)>, <2 x \(memType)> addrspace(3)* %\(p)typed, align \(elemSize * 2)\n"
+
+      if memPrec != regPrec {
+        ir += "  %\(p)e0 = extractelement <2 x \(memType)> %\(p)load, i32 0\n"
+        ir += "  %\(p)e1 = extractelement <2 x \(memType)> %\(p)load, i32 1\n"
+        ir += "  %\(p)ext0 = fpext \(memType) %\(p)e0 to \(regType)\n"
+        ir += "  %\(p)ext1 = fpext \(memType) %\(p)e1 to \(regType)\n"
+        ir += "  %\(p)v2_a = insertelement <2 x \(regType)> undef, \(regType) %\(p)ext0, i32 0\n"
+        ir += "  %\(p)v2 = insertelement <2 x \(regType)> %\(p)v2_a, \(regType) %\(p)ext1, i32 1\n"
+      } else {
+        ir += "  %\(p)v2 = bitcast <2 x \(memType)> %\(p)load to <2 x \(memType)>\n"
+      }
+    }
+
+    // Expand <2 x T> to <64 x T>
+    ir += irShuffleToVec64(result: "%\(p)sram", src: "%\(p)v2", type: regPrec) + "\n"
+
+    return ir
+  }
+
+  // MARK: - Load from Device into Register (SIMD matrix)
+
+  /// Generate IR to load a <2 x T> directly from device memory (addrspace 1),
+  /// convert precision, and expand to <64 x T> via insertelement.
+  /// bufferName: SSA name of the device pointer (e.g., "%Q")
+  /// seqOffset: SSA name or literal for the sequence offset of this thread
+  /// headOffset: SSA name or literal for the head offset of this thread
+  /// leadingDim: the leading dimension of the buffer
+  func generateDeviceLoad(
+    prefix p: String,
+    bufferName: String,
+    seqOffset: String,         // row in non-transposed (e.g., "%par_group_off + oig_y")
+    headOffset: String,        // col in non-transposed (e.g., "d_outer + morton_x * 8")
+    leadingDim: UInt32,
+    memPrec: GEMMOperandPrecision,
+    regPrec: GEMMOperandPrecision,
+    transposed: Bool
+  ) -> String {
+    let elemSize = UInt32(memPrec.size)
+    let memType = irTypeName(memPrec)
+    let regType = irTypeName(regPrec)
+    var ir = ""
+
+    if transposed {
+      // Transposed: each thread reads 2 elements at (row+0, col) and (row+1, col)
+      for elem in 0..<2 {
+        ir += "  %\(p)r_\(elem) = add i32 \(headOffset), \(elem)\n"
+        ir += "  %\(p)addr_\(elem) = mul i32 %\(p)r_\(elem), \(leadingDim)\n"
+        ir += "  %\(p)addr2_\(elem) = add i32 %\(p)addr_\(elem), \(seqOffset)\n"
+        ir += "  %\(p)byte_\(elem) = mul i32 %\(p)addr2_\(elem), \(elemSize)\n"
+        ir += "  %\(p)byte64_\(elem) = zext i32 %\(p)byte_\(elem) to i64\n"
+        ir += "  %\(p)ptr_\(elem) = getelementptr i8, i8 addrspace(1)* \(bufferName), i64 %\(p)byte64_\(elem)\n"
+        ir += "  %\(p)typed_\(elem) = bitcast i8 addrspace(1)* %\(p)ptr_\(elem) to \(memType) addrspace(1)*\n"
+        ir += "  %\(p)load_\(elem) = load \(memType), \(memType) addrspace(1)* %\(p)typed_\(elem)\n"
+      }
+      if memPrec != regPrec {
+        for elem in 0..<2 {
+          ir += "  %\(p)ext_\(elem) = fpext \(memType) %\(p)load_\(elem) to \(regType)\n"
+        }
+        ir += "  %\(p)v2_a = insertelement <2 x \(regType)> undef, \(regType) %\(p)ext_0, i32 0\n"
+        ir += "  %\(p)v2 = insertelement <2 x \(regType)> %\(p)v2_a, \(regType) %\(p)ext_1, i32 1\n"
+      } else {
+        ir += "  %\(p)v2_a = insertelement <2 x \(memType)> undef, \(memType) %\(p)load_0, i32 0\n"
+        ir += "  %\(p)v2 = insertelement <2 x \(memType)> %\(p)v2_a, \(memType) %\(p)load_1, i32 1\n"
+      }
+    } else {
+      // Non-transposed: load contiguous <2 x T> from row-major layout
+      ir += "  %\(p)addr = mul i32 \(seqOffset), \(leadingDim)\n"
+      ir += "  %\(p)addr2 = add i32 %\(p)addr, \(headOffset)\n"
+      ir += "  %\(p)byte = mul i32 %\(p)addr2, \(elemSize)\n"
+      ir += "  %\(p)byte64 = zext i32 %\(p)byte to i64\n"
+      ir += "  %\(p)ptr = getelementptr i8, i8 addrspace(1)* \(bufferName), i64 %\(p)byte64\n"
+      ir += "  %\(p)typed = bitcast i8 addrspace(1)* %\(p)ptr to <2 x \(memType)> addrspace(1)*\n"
+      ir += "  %\(p)load = load <2 x \(memType)>, <2 x \(memType)> addrspace(1)* %\(p)typed, align \(elemSize * 2)\n"
+
+      if memPrec != regPrec {
+        ir += "  %\(p)e0 = extractelement <2 x \(memType)> %\(p)load, i32 0\n"
+        ir += "  %\(p)e1 = extractelement <2 x \(memType)> %\(p)load, i32 1\n"
+        ir += "  %\(p)ext0 = fpext \(memType) %\(p)e0 to \(regType)\n"
+        ir += "  %\(p)ext1 = fpext \(memType) %\(p)e1 to \(regType)\n"
+        ir += "  %\(p)v2_a = insertelement <2 x \(regType)> undef, \(regType) %\(p)ext0, i32 0\n"
+        ir += "  %\(p)v2 = insertelement <2 x \(regType)> %\(p)v2_a, \(regType) %\(p)ext1, i32 1\n"
+      } else {
+        ir += "  %\(p)v2 = bitcast <2 x \(memType)> %\(p)load to <2 x \(memType)>\n"
+      }
+    }
+
+    // Expand <2 x T> to <64 x T>
+    ir += irShuffleToVec64(result: "%\(p)sram", src: "%\(p)v2", type: regPrec) + "\n"
+
+    return ir
+  }
+
+  // MARK: - Outer Product (S = A * B^T)
+
+  /// Generate the outer product: for each d_outer block, async copy B to TG,
+  /// barrier, load A from device or cache, load B tiles from TG interleaved
+  /// with matmul.
+  ///
+  /// For B (RHS): always uses TG via async copy.
+  /// For A (LHS): uses cached registers if cachedA, otherwise loads directly
+  /// from device memory (matching the reference's pattern).
+  ///
+  /// Result: S accumulators are in %{C_name}_final_0 .. %{C_name}_final_{count-1}
+  func generateOuterProduct(
+    prefix p: String,
+    A: AttentionOperand, B: AttentionOperand, C_name: String,
+    sSramCount: Int,
+    blockP: UInt16, blockT: UInt16, blockH: UInt16,
+    D: UInt32, paddedD: UInt32, headEdge: UInt32,
+    headLoopFloor: UInt32,
+    parallelDim: UInt32, traversalDim: UInt32,
+    traversalOffset: String,
+    regA: GEMMOperandPrecision, regB: GEMMOperandPrecision,
+    regC: GEMMOperandPrecision,
+    memA: GEMMOperandPrecision, memB: GEMMOperandPrecision,
+    leadingDimA: UInt32, leadingDimB: UInt32,
+    leadingBlockDimA: UInt32, leadingBlockDimB: UInt32,
+    cachedA: Bool,
+    transposedA: Bool, transposedB: Bool,
+    cachePrefix: String = "cq_",  // prefix for cached A registers (e.g., "cq_", "ck_", "cv_", "cdo_")
+    tgOffset: String = "0",             // byte offset into TG for B (K) slot
+    skipFirstIterCopy: Bool = false     // if true, skip first d_outer iteration's async copy (TG already loaded)
+  ) -> String {
+    var ir = ""
+    ir += "  ; === Outer Product \(A) * \(B)^T → \(C_name) ===\n"
+
+    // Current accumulator names (chained through d_outer iterations)
+    var cNames = (0..<sSramCount).map { "%\(C_name)_init_\($0)" }
+
+    // Head masking for B (K/V) TG loads: when D < paddedD, TG columns beyond D
+    // contain garbage (async_copy doesn't zero-fill). If a thread's head position
+    // >= D, the loaded register must be zeroed to prevent NaN poisoning the matmul.
+    // The head position for B's TG load depends on transpose state:
+    //   non-transposed B: col = morton_y + kOff  (head dim along TG columns)
+    //   transposed B:     row = morton_y + kOff  (head dim along TG rows)
+    // In both cases, morton_y + kOff is the head offset to check against D.
+    let needsHeadMaskB = D < paddedD
+
+    // We unroll the head dimension loop at codegen time (same as Metal source)
+    // Head loop: d_outer from 0 to headLoopFloor by blockH, then edge
+    func emitHeadIteration(dOuterVal: UInt32, regSize: UInt32, iterIdx: Int) {
+      let ip = "\(p)\(iterIdx)_"
+      let dOuterStr = "\(dOuterVal)"
+      let kSteps = Int(regSize / 8)
+
+      if !cachedA {
+        // A (Q) not cached: load Q directly from device, K via TG.
+        // Matches reference pattern: async_copy K→TG, barrier, then
+        // for each d { load Q from device, load K from TG, matmul }.
+        // This avoids the extra async copy + barrier for Q entirely.
+
+        // Async copy B (K) to TG (skip first iter if already loaded externally)
+        if !(skipFirstIterCopy && iterIdx == 0) {
+          ir += generateAsyncCopyDeviceToTG(
+            prefix: "\(ip)b",
+            buffer: "%\(B)",
+            operand: B,
+            dOuter: dOuterStr,
+            seqOffset: traversalOffset,
+            seqDim: traversalDim,
+            blockSeq: blockT,
+            blockHead: UInt16(regSize),
+            D: D,
+            leadingDim: leadingDimB,
+            leadingBlockDim: leadingBlockDimB,
+            memPrec: memB,
+            transposed: transposedB,
+            tgOffset: tgOffset
+          )
+        }
+
+        // Head masking for A (Q) when not cached — same NaN prevention
+        // as cached Q, but applied per d-step in the uncached path.
+        let needsHeadMaskA = D < paddedD
+
+        // Interleaved: for each d step, load Q from device, then
+        // for each traversal tile, load K from TG + matmul.
+        for k in 0..<kSteps {
+          let kOff = k * 8
+          let headOffsetA = Int(dOuterVal) + kOff
+
+          // Load A (Q) directly from device memory for this d step
+          let aPrefix = "\(ip)a\(k)_"
+          let aNeedsMask = needsHeadMaskA && headOffsetA + 8 > Int(D)
+
+          // Check at codegen time: is this entire k-step beyond D?
+          if needsHeadMaskA && headOffsetA >= D {
+            ir += "  %\(aPrefix)sram = bitcast \(irVecType(regA)) zeroinitializer to \(irVecType(regA))\n"
+          } else {
+            let aLoadPrefix = aNeedsMask ? "\(aPrefix)r_" : aPrefix
+            // Q address: Q[seq, head] where seq = parallelization thread offset,
+            // head = d_outer + kOff + morton_x (each thread's 2 elements)
+            if transposedA {
+              // Q stored as Q^T[head, seq]: addr = (head) * leadingDimA + (seq)
+              ir += "  %\(aLoadPrefix)seq = add i32 %clamped_par_off, 0\n"
+              ir += "  %\(aLoadPrefix)head = add i32 %morton_x, \(headOffsetA)\n"
+              ir += generateDeviceLoad(
+                prefix: aLoadPrefix,
+                bufferName: "%\(A)",
+                seqOffset: "%\(aLoadPrefix)seq",
+                headOffset: "%\(aLoadPrefix)head",
+                leadingDim: leadingDimA,
+                memPrec: memA,
+                regPrec: regA,
+                transposed: true
+              )
+            } else {
+              // Q stored as Q[seq, head]: addr = (seq) * leadingDimA + (head)
+              ir += "  %\(aLoadPrefix)seq = add i32 %clamped_par_off, 0\n"
+              ir += "  %\(aLoadPrefix)head = add i32 %morton_x, \(headOffsetA)\n"
+              ir += generateDeviceLoad(
+                prefix: aLoadPrefix,
+                bufferName: "%\(A)",
+                seqOffset: "%\(aLoadPrefix)seq",
+                headOffset: "%\(aLoadPrefix)head",
+                leadingDim: leadingDimA,
+                memPrec: memA,
+                regPrec: regA,
+                transposed: false
+              )
+            }
+
+            // Head masking: zero when morton_x + headOffset >= D
+            // morton_x ∈ {0,2,4,6} already gives the head column position
+            if aNeedsMask {
+              ir += "  %\(aPrefix)hpos = add i32 %morton_x, \(headOffsetA)\n"
+              ir += "  %\(aPrefix)oob = icmp uge i32 %\(aPrefix)hpos, \(D)\n"
+              ir += "  %\(aPrefix)sram = select i1 %\(aPrefix)oob, \(irVecType(regA)) zeroinitializer, \(irVecType(regA)) %\(aLoadPrefix)sram\n"
+            }
+          }
+
+          // Load B (K) tiles from TG and multiply immediately
+          for t in 0..<sSramCount {
+            let tOff = t * 8
+            let bPrefix = "\(ip)b\(k)x\(t)_"
+            let headOffsetB = Int(dOuterVal) + kOff
+            let bNeedsMask = needsHeadMaskB && headOffsetB + 8 > Int(D)
+
+            // Check at codegen time: is this entire k-step beyond D?
+            if needsHeadMaskB && headOffsetB >= D {
+              // Entire B register is beyond D — zero it
+              ir += "  %\(bPrefix)sram = bitcast \(irVecType(regB)) zeroinitializer to \(irVecType(regB))\n"
+            } else {
+              // Use a raw prefix when head masking is needed, so TG load
+              // produces %{raw}sram and we can select into %{b}sram
+              let loadPrefix = bNeedsMask ? "\(bPrefix)r_" : bPrefix
+              if transposedB {
+                ir += "  %\(loadPrefix)row = add i32 %morton_y, \(kOff)\n"
+                ir += "  %\(loadPrefix)col = add i32 %morton_x, \(tOff)\n"
+              } else {
+                ir += "  %\(loadPrefix)row = add i32 %morton_x, \(tOff)\n"
+                ir += "  %\(loadPrefix)col = add i32 %morton_y, \(kOff)\n"
+              }
+              ir += generateTGLoad(
+                prefix: loadPrefix,
+                tgOffset: tgOffset,
+                rowOffset: "%\(loadPrefix)row",
+                colOffset: "%\(loadPrefix)col",
+                leadingBlockDim: leadingBlockDimB,
+                memPrec: memB,
+                regPrec: regB,
+                transposed: !transposedB
+              )
+
+              // Head masking: zero the register if this thread's head position >= D
+              if bNeedsMask {
+                ir += "  %\(bPrefix)hpos = add i32 %morton_y, \(headOffsetB)\n"
+                ir += "  %\(bPrefix)oob = icmp uge i32 %\(bPrefix)hpos, \(D)\n"
+                ir += "  %\(bPrefix)sram = select i1 %\(bPrefix)oob, \(irVecType(regB)) zeroinitializer, \(irVecType(regB)) %\(loadPrefix)sram\n"
+              }
+            }
+
+            let cIn = (k == 0) ? cNames[t] : "%\(ip)c\(k-1)x\(t)"
+            let cOut = "%\(ip)c\(k)x\(t)"
+            ir += irMultiplyAccumulateCall(
+              result: cOut,
+              A: ("%\(aPrefix)sram", regA),
+              B: ("%\(bPrefix)sram", regB),
+              C: (cIn, regC)
+            ) + "\n"
+          }
+        }
+
+      } else {
+        // A is cached: only B needs TG. Copy B → load B → use cached A → matmul.
+        if !(skipFirstIterCopy && iterIdx == 0) {
+          ir += generateAsyncCopyDeviceToTG(
+            prefix: "\(ip)b",
+            buffer: "%\(B)",
+            operand: B,
+            dOuter: dOuterStr,
+            seqOffset: traversalOffset,
+            seqDim: traversalDim,
+            blockSeq: blockT,
+            blockHead: UInt16(regSize),
+            D: D,
+            leadingDim: leadingDimB,
+            leadingBlockDim: leadingBlockDimB,
+            memPrec: memB,
+            transposed: transposedB,
+            tgOffset: tgOffset
+          )
+        }
+
+        for k in 0..<kSteps {
+          let kOff = k * 8
+
+          // Use cached A register
+          let aPrefix = "\(ip)a\(k)_"
+          let cachedIdx = (Int(dOuterVal) + kOff) / 8
+          ir += "  %\(aPrefix)sram = bitcast \(irVecType(regA)) %\(cachePrefix)sram_\(cachedIdx) to \(irVecType(regA))\n"
+
+          // Load B tile(s) and multiply-accumulate
+          for t in 0..<sSramCount {
+            let tOff = t * 8
+            let bPrefix = "\(ip)b\(k)x\(t)_"
+            let headOffsetB = Int(dOuterVal) + kOff
+            let bNeedsMask = needsHeadMaskB && headOffsetB + 8 > Int(D)
+
+            if needsHeadMaskB && headOffsetB >= D {
+              ir += "  %\(bPrefix)sram = bitcast \(irVecType(regB)) zeroinitializer to \(irVecType(regB))\n"
+            } else {
+              let loadPrefix = bNeedsMask ? "\(bPrefix)r_" : bPrefix
+              if transposedB {
+                ir += "  %\(loadPrefix)row = add i32 %morton_y, \(kOff)\n"
+                ir += "  %\(loadPrefix)col = add i32 %morton_x, \(tOff)\n"
+              } else {
+                ir += "  %\(loadPrefix)row = add i32 %morton_x, \(tOff)\n"
+                ir += "  %\(loadPrefix)col = add i32 %morton_y, \(kOff)\n"
+              }
+              ir += generateTGLoad(
+                prefix: loadPrefix,
+                tgOffset: tgOffset,
+                rowOffset: "%\(loadPrefix)row",
+                colOffset: "%\(loadPrefix)col",
+                leadingBlockDim: leadingBlockDimB,
+                memPrec: memB,
+                regPrec: regB,
+                transposed: !transposedB
+              )
+
+              if bNeedsMask {
+                ir += "  %\(bPrefix)hpos = add i32 %morton_y, \(headOffsetB)\n"
+                ir += "  %\(bPrefix)oob = icmp uge i32 %\(bPrefix)hpos, \(D)\n"
+                ir += "  %\(bPrefix)sram = select i1 %\(bPrefix)oob, \(irVecType(regB)) zeroinitializer, \(irVecType(regB)) %\(loadPrefix)sram\n"
+              }
+            }
+
+            let cIn = (k == 0) ? cNames[t] : "%\(ip)c\(k-1)x\(t)"
+            let cOut = "%\(ip)c\(k)x\(t)"
+            ir += irMultiplyAccumulateCall(
+              result: cOut,
+              A: ("%\(aPrefix)sram", regA),
+              B: ("%\(bPrefix)sram", regB),
+              C: (cIn, regC)
+            ) + "\n"
+          }
+        }
+      }
+
+      // Barrier before next head iteration overwrites TG
+      ir += "  call void @air.wg.barrier(i32 2, i32 1)\n\n"
+
+      // Update accumulator names
+      let lastK = kSteps - 1
+      cNames = (0..<sSramCount).map { "%\(ip)c\(lastK)x\($0)" }
+    }
+
+    // Emit head iterations
+    var iterIdx = 0
+    var dOuter: UInt32 = 0
+    while dOuter < headLoopFloor {
+      emitHeadIteration(dOuterVal: dOuter, regSize: UInt32(blockH), iterIdx: iterIdx)
+      dOuter += UInt32(blockH)
+      iterIdx += 1
+    }
+    // Edge iteration if needed
+    if headLoopFloor < paddedD {
+      emitHeadIteration(dOuterVal: headLoopFloor, regSize: headEdge, iterIdx: iterIdx)
+    }
+
+    // Final names
+    for i in 0..<sSramCount {
+      ir += "  %\(C_name)_final_\(i) = bitcast \(irVecType(regC)) \(cNames[i]) to \(irVecType(regC))\n"
+    }
+
+    return ir
+  }
+
+  // MARK: - Mask Attention Matrix Edge
+
+  func generateMaskEdge(
+    prefix p: String,
+    sSramCount: Int,
+    blockT: UInt16, traversalDim: UInt32,
+    traversalOffset: String,
+    regS: GEMMOperandPrecision,
+    scaleFactor: Float
+  ) -> String {
+    let logBase2E: Float = 1.442695041
+    let t = irTypeName(regS)
+    var ir = ""
+
+    ir += "  ; === Mask attention matrix edge ===\n"
+
+    // remainder = traversalDim % blockT
+    let remainder = traversalDim % UInt32(blockT)
+    if remainder == 0 {
+      // No masking needed when traversal is perfectly divisible
+      // But we still need to handle the case at runtime
+      ir += "  ; No edge masking needed (traversalDim divisible by blockT)\n"
+      for i in 0..<sSramCount {
+        ir += "  %\(p)s_\(i) = bitcast \(irVecType(regS)) %s_final_\(i) to \(irVecType(regS))\n"
+      }
+      return ir
+    }
+
+    // Check if this is an edge iteration
+    let blockEnd = "%\(p)block_end"
+    ir += "  \(blockEnd) = add i32 \(traversalOffset), \(blockT)\n"
+    ir += "  %\(p)is_edge = icmp ugt i32 \(blockEnd), \(traversalDim)\n"
+    ir += "  br i1 %\(p)is_edge, label %\(p)do_mask, label %\(p)skip_mask\n\n"
+
+    ir += "\(p)do_mask:\n"
+    // mask_value = (0.875 / logBase2E) * -FLT_MAX
+    let maskValue: Float = (0.875 / logBase2E) * -Float.greatestFiniteMagnitude
+    ir += "  %\(p)mask_val_f32 = bitcast i32 \(maskValue.bitPattern) to float\n"
+    let maskValName: String
+    if regS == .FP32 {
+      maskValName = "%\(p)mask_val_f32"
+    } else {
+      maskValName = "%\(p)mask_val_cvt"
+      ir += "  \(maskValName) = fptrunc float %\(p)mask_val_f32 to \(irTypeName(regS))\n"
+    }
+
+    // Compute which elements to mask
+    // remainder_rt = traversalDim - traversalOffset (runtime remainder)
+    ir += "  %\(p)rem_rt = sub i32 \(traversalDim), \(traversalOffset)\n"
+    // remainderFloor = rem_rt - (rem_rt % 8)
+    ir += "  %\(p)rem_mod8 = and i32 %\(p)rem_rt, 7\n"
+    ir += "  %\(p)rem_floor = sub i32 %\(p)rem_rt, %\(p)rem_mod8\n"
+
+    // For the block at remainderFloor/8, mask elements where morton_x + index >= remainder - remainderFloor
+    // For blocks after remainderFloor, mask all elements
+    for i in 0..<sSramCount {
+      let blockStart = i * 8
+      // If blockStart >= rem_rt, mask everything
+      ir += "  %\(p)bs_\(i) = icmp uge i32 \(blockStart), %\(p)rem_rt\n"
+
+      // Extract the 2 thread elements
+      ir += "  %\(p)e0_\(i) = extractelement \(irVecType(regS)) %s_final_\(i), i32 0\n"
+      ir += "  %\(p)e1_\(i) = extractelement \(irVecType(regS)) %s_final_\(i), i32 1\n"
+
+      // For the edge block (blockStart == remainderFloor):
+      // mask element if morton_x + index >= (rem_rt - remainderFloor)
+      ir += "  %\(p)is_edge_blk_\(i) = icmp eq i32 \(blockStart), %\(p)rem_floor\n"
+
+      // element 0: mask if morton_x + 0 >= rem_mod8
+      ir += "  %\(p)e0_oob_\(i) = icmp uge i32 %morton_x, %\(p)rem_mod8\n"
+      ir += "  %\(p)e0_mask_\(i) = and i1 %\(p)is_edge_blk_\(i), %\(p)e0_oob_\(i)\n"
+      // element 1: mask if morton_x + 1 >= rem_mod8
+      ir += "  %\(p)mx_p1_\(i) = add i32 %morton_x, 1\n"
+      ir += "  %\(p)e1_oob_\(i) = icmp uge i32 %\(p)mx_p1_\(i), %\(p)rem_mod8\n"
+      ir += "  %\(p)e1_mask_\(i) = and i1 %\(p)is_edge_blk_\(i), %\(p)e1_oob_\(i)\n"
+
+      // Combine: mask if full block OOB or individual element OOB
+      ir += "  %\(p)m0_\(i) = or i1 %\(p)bs_\(i), %\(p)e0_mask_\(i)\n"
+      ir += "  %\(p)m1_\(i) = or i1 %\(p)bs_\(i), %\(p)e1_mask_\(i)\n"
+
+      // Select masked values
+      let maskCast = maskValName
+      ir += "  %\(p)me0_\(i) = select i1 %\(p)m0_\(i), \(t) \(maskCast), \(t) %\(p)e0_\(i)\n"
+      ir += "  %\(p)me1_\(i) = select i1 %\(p)m1_\(i), \(t) \(maskCast), \(t) %\(p)e1_\(i)\n"
+
+      // Reconstruct <64 x T>
+      ir += "  %\(p)sv0_\(i) = insertelement \(irVecType(regS)) %s_final_\(i), \(t) %\(p)me0_\(i), i32 0\n"
+      ir += "  %\(p)masked_\(i) = insertelement \(irVecType(regS)) %\(p)sv0_\(i), \(t) %\(p)me1_\(i), i32 1\n"
+    }
+
+    ir += "  br label %\(p)after_mask\n\n"
+    ir += "\(p)skip_mask:\n"
+    ir += "  br label %\(p)after_mask\n\n"
+    ir += "\(p)after_mask:\n"
+
+    // Phi nodes
+    for i in 0..<sSramCount {
+      ir += "  %\(p)s_\(i) = phi \(irVecType(regS)) [%\(p)masked_\(i), %\(p)do_mask], [%s_final_\(i), %\(p)skip_mask]\n"
+    }
+    ir += "\n"
+
+    return ir
+  }
+
+  // MARK: - Online Softmax: Reduce Maximum
+
+  func generateReduceMax(
+    prefix p: String,
+    sSramCount: Int,
+    regS: GEMMOperandPrecision,
+    scaleFactor: Float
+  ) -> String {
+    let t = irTypeName(regS)
+    var ir = ""
+
+    ir += "  ; === Reduce max ===\n"
+
+    // Extract element pairs and compute max
+    for i in 0..<sSramCount {
+      ir += "  %\(p)e0_\(i) = extractelement \(irVecType(regS)) %mask_s_\(i), i32 0\n"
+      ir += "  %\(p)e1_\(i) = extractelement \(irVecType(regS)) %mask_s_\(i), i32 1\n"
+      if i == 0 {
+        ir += "  %\(p)max_\(i) = fcmp fast ogt \(t) %\(p)e0_\(i), %\(p)e1_\(i)\n"
+        ir += "  %\(p)m_\(i) = select i1 %\(p)max_\(i), \(t) %\(p)e0_\(i), \(t) %\(p)e1_\(i)\n"
+      } else {
+        let prev = "%\(p)m_\(i-1)"
+        ir += "  %\(p)cmp0_\(i) = fcmp fast ogt \(t) %\(p)e0_\(i), \(prev)\n"
+        ir += "  %\(p)sel0_\(i) = select i1 %\(p)cmp0_\(i), \(t) %\(p)e0_\(i), \(t) \(prev)\n"
+        ir += "  %\(p)cmp1_\(i) = fcmp fast ogt \(t) %\(p)e1_\(i), %\(p)sel0_\(i)\n"
+        ir += "  %\(p)m_\(i) = select i1 %\(p)cmp1_\(i), \(t) %\(p)e1_\(i), \(t) %\(p)sel0_\(i)\n"
+      }
+    }
+
+    let lastM = "%\(p)m_\(sSramCount - 1)"
+
+    // SIMD reduction: shuffle_xor with masks 1 and 8
+    // m_new = max across thread elements
+    if t == "float" {
+      ir += "  %\(p)mf = bitcast float \(lastM) to float\n"
+    } else {
+      ir += "  %\(p)mf = fpext \(t) \(lastM) to float\n"
+    }
+    ir += irShuffleXorCall(result: "%\(p)shuf1", value: "%\(p)mf", mask: 1) + "\n"
+    ir += "  %\(p)cmp_s1 = fcmp fast ogt float %\(p)mf, %\(p)shuf1\n"
+    ir += "  %\(p)max_s1 = select i1 %\(p)cmp_s1, float %\(p)mf, float %\(p)shuf1\n"
+    ir += irShuffleXorCall(result: "%\(p)shuf8", value: "%\(p)max_s1", mask: 8) + "\n"
+    ir += "  %\(p)cmp_s8 = fcmp fast ogt float %\(p)max_s1, %\(p)shuf8\n"
+    ir += "  %\(p)m_new = select i1 %\(p)cmp_s8, float %\(p)max_s1, float %\(p)shuf8\n"
+
+    // Scale by scaleFactor
+    let scaleDoubleHex = String(Double(scaleFactor).bitPattern, radix: 16, uppercase: true)
+    ir += "  %\(p)m_new_scaled = fmul fast float %\(p)m_new, 0x\(scaleDoubleHex)\n"
+
+    return ir
+  }
+
+  // MARK: - Online Softmax: Correct O
+
+  func generateCorrectO(
+    prefix p: String,
+    oCachedCount: Int,
+    regO: GEMMOperandPrecision
+  ) -> String {
+    var ir = ""
+    ir += "  ; === Correct O ===\n"
+
+    // correction = (m_new > m) ? exp2(m - m_new) : 1.0
+    ir += "  %\(p)m_gt = fcmp fast ogt float %rmax_m_new_scaled, %m_phi\n"
+    ir += "  %\(p)m_diff = fsub fast float %m_phi, %rmax_m_new_scaled\n"
+    ir += irExp2Call(result: "%\(p)exp_diff", value: "%\(p)m_diff") + "\n"
+    ir += "  %\(p)correction = select i1 %\(p)m_gt, float %\(p)exp_diff, float 1.0\n"
+
+    // m = max(m, m_new)
+    // (already computed as rmax_m_new_scaled, but update only if new > old)
+    ir += "  %\(p)m_upd = select i1 %\(p)m_gt, float %rmax_m_new_scaled, float %m_phi\n"
+
+    return ir
+  }
+
+  // MARK: - Online Softmax: Compute P = exp2(S * scale - m)
+
+  func generateComputeP(
+    prefix p: String,
+    sSramCount: Int,
+    regS: GEMMOperandPrecision,
+    regP: GEMMOperandPrecision,
+    scaleFactor: Float
+  ) -> String {
+    let tS = irTypeName(regS)
+    let tP = irTypeName(regP)
+    var ir = ""
+
+    ir += "  ; === Compute P = exp2(S * scale - m) ===\n"
+
+    for i in 0..<sSramCount {
+      // Extract S elements
+      ir += "  %\(p)s0_\(i) = extractelement \(irVecType(regS)) %mask_s_\(i), i32 0\n"
+      ir += "  %\(p)s1_\(i) = extractelement \(irVecType(regS)) %mask_s_\(i), i32 1\n"
+
+      // Convert to float for exp2
+      let s0f = (regS == .FP32) ? "%\(p)s0_\(i)" : "%\(p)s0f_\(i)"
+      let s1f = (regS == .FP32) ? "%\(p)s1_\(i)" : "%\(p)s1f_\(i)"
+      if regS != .FP32 {
+        ir += "  \(s0f) = fpext \(tS) %\(p)s0_\(i) to float\n"
+        ir += "  \(s1f) = fpext \(tS) %\(p)s1_\(i) to float\n"
+      }
+
+      // P_i = exp2(S_i * scaleFactor - m)
+      let scaleHex = "0x\(String(Double(scaleFactor).bitPattern, radix: 16, uppercase: true))"
+      ir += "  %\(p)scaled0_\(i) = fmul fast float \(s0f), \(scaleHex)\n"
+      ir += "  %\(p)shifted0_\(i) = fsub fast float %\(p)scaled0_\(i), %corr_m_upd\n"
+      ir += irExp2Call(result: "%\(p)p0f_\(i)", value: "%\(p)shifted0_\(i)") + "\n"
+
+      ir += "  %\(p)scaled1_\(i) = fmul fast float \(s1f), \(scaleHex)\n"
+      ir += "  %\(p)shifted1_\(i) = fsub fast float %\(p)scaled1_\(i), %corr_m_upd\n"
+      ir += irExp2Call(result: "%\(p)p1f_\(i)", value: "%\(p)shifted1_\(i)") + "\n"
+
+      // Convert back to P precision and construct <64 x T>
+      let p0 = (regP == .FP32) ? "%\(p)p0f_\(i)" : "%\(p)p0_\(i)"
+      let p1 = (regP == .FP32) ? "%\(p)p1f_\(i)" : "%\(p)p1_\(i)"
+      if regP != .FP32 {
+        ir += "  \(p0) = fptrunc float %\(p)p0f_\(i) to \(tP)\n"
+        ir += "  \(p1) = fptrunc float %\(p)p1f_\(i) to \(tP)\n"
+      }
+
+      ir += "  %\(p)pv0_\(i) = insertelement \(irVecType(regP)) undef, \(tP) \(p0), i32 0\n"
+      ir += "  %\(p)p_\(i) = insertelement \(irVecType(regP)) %\(p)pv0_\(i), \(tP) \(p1), i32 1\n"
+    }
+
+    return ir
+  }
+
+  // MARK: - Online Softmax: Reduce Sum
+
+  func generateReduceSum(
+    prefix p: String,
+    sSramCount: Int,
+    regP: GEMMOperandPrecision
+  ) -> String {
+    let tP = irTypeName(regP)
+    var ir = ""
+
+    ir += "  ; === Reduce sum ===\n"
+
+    // Sum P elements
+    for i in 0..<sSramCount {
+      ir += "  %\(p)e0_\(i) = extractelement \(irVecType(regP)) %sp_p_\(i), i32 0\n"
+      ir += "  %\(p)e1_\(i) = extractelement \(irVecType(regP)) %sp_p_\(i), i32 1\n"
+
+      let e0f = (regP == .FP32) ? "%\(p)e0_\(i)" : "%\(p)e0f_\(i)"
+      let e1f = (regP == .FP32) ? "%\(p)e1_\(i)" : "%\(p)e1f_\(i)"
+      if regP != .FP32 {
+        ir += "  \(e0f) = fpext \(tP) %\(p)e0_\(i) to float\n"
+        ir += "  \(e1f) = fpext \(tP) %\(p)e1_\(i) to float\n"
+      }
+
+      if i == 0 {
+        ir += "  %\(p)sum_\(i) = fadd fast float \(e0f), \(e1f)\n"
+      } else {
+        ir += "  %\(p)add0_\(i) = fadd fast float %\(p)sum_\(i-1), \(e0f)\n"
+        ir += "  %\(p)sum_\(i) = fadd fast float %\(p)add0_\(i), \(e1f)\n"
+      }
+    }
+
+    let lastSum = "%\(p)sum_\(sSramCount - 1)"
+
+    // SIMD reduction
+    ir += irShuffleXorCall(result: "%\(p)shuf1", value: lastSum, mask: 1) + "\n"
+    ir += "  %\(p)sum_s1 = fadd fast float \(lastSum), %\(p)shuf1\n"
+    ir += irShuffleXorCall(result: "%\(p)shuf8", value: "%\(p)sum_s1", mask: 8) + "\n"
+    ir += "  %\(p)l_new_part = fadd fast float %\(p)sum_s1, %\(p)shuf8\n"
+
+    // l = l * correction + l_new
+    ir += "  %\(p)l_corrected = fmul fast float %l_phi, %corr_correction\n"
+    ir += "  %\(p)l_new = fadd fast float %\(p)l_corrected, %\(p)l_new_part\n"
+
+    return ir
+  }
+
+  // MARK: - Accumulate O += P * V
+
+  func generateAccumulate(
+    prefix p: String,
+    A: AttentionOperand, B: AttentionOperand, C_name: String,
+    accCount: Int,
+    blockP: UInt16, blockT: UInt16, blockH: UInt16,
+    D: UInt32, paddedD: UInt32, headEdge: UInt32,
+    headLoopFloor: UInt32,
+    parallelDim: UInt32, traversalDim: UInt32,
+    traversalOffset: String,
+    regA: GEMMOperandPrecision, regB: GEMMOperandPrecision,
+    regC: GEMMOperandPrecision,
+    memB: GEMMOperandPrecision,
+    leadingDimB: UInt32,
+    leadingBlockDimB: UInt32,
+    transposedB: Bool,
+    cachedC: Bool,
+    isFinalScale: Bool,
+    scaleCorrection: String,  // SSA name of correction factor (or "" if none)
+    aSourcePrefix: String = "sp_p",       // SSA prefix for A registers (e.g., "sp_p" → %sp_p_0)
+    tgOffset: String = "0",              // byte offset into TG for V slot
+    skipFirstIterCopy: Bool = false      // if true, skip first d_outer iteration's async copy
+  ) -> String {
+    var ir = ""
+    ir += "  ; === Accumulate \(C_name) += P * V ===\n"
+
+    // Note: head masking in the accumulate uses %morton_x directly.
+    // morton_x ∈ {0,2,4,6} already gives the head column position.
+
+    // Scale existing accumulators by correction
+    if !scaleCorrection.isEmpty {
+      for i in 0..<accCount {
+        ir += "  %\(p)scale_e0_\(i) = extractelement \(irVecType(regC)) %\(C_name)_phi_\(i), i32 0\n"
+        ir += "  %\(p)scale_e1_\(i) = extractelement \(irVecType(regC)) %\(C_name)_phi_\(i), i32 1\n"
+        ir += "  %\(p)scaled_e0_\(i) = fmul fast float %\(p)scale_e0_\(i), %\(scaleCorrection)\n"
+        ir += "  %\(p)scaled_e1_\(i) = fmul fast float %\(p)scale_e1_\(i), %\(scaleCorrection)\n"
+        ir += "  %\(p)sv0_\(i) = insertelement \(irVecType(regC)) %\(C_name)_phi_\(i), float %\(p)scaled_e0_\(i), i32 0\n"
+        ir += "  %\(p)corrected_\(i) = insertelement \(irVecType(regC)) %\(p)sv0_\(i), float %\(p)scaled_e1_\(i), i32 1\n"
+      }
+    } else {
+      for i in 0..<accCount {
+        ir += "  %\(p)corrected_\(i) = bitcast \(irVecType(regC)) %\(C_name)_phi_\(i) to \(irVecType(regC))\n"
+      }
+    }
+
+    // For each d_outer block of the head dimension:
+    //   1. Async copy V to TG
+    //   2. Barrier
+    //   3. Matmul: O_block += P * V_block
+    var cNames = (0..<accCount).map { "%\(p)corrected_\($0)" }
+
+    func emitHeadIteration(dOuterVal: UInt32, regSize: UInt32, iterIdx: Int) {
+      let ip = "\(p)\(iterIdx)_"
+
+      // Async copy V to TG (skip first iter if already loaded externally)
+      if !(skipFirstIterCopy && iterIdx == 0) {
+        ir += generateAsyncCopyDeviceToTG(
+          prefix: "\(ip)v",
+          buffer: "%\(B)",
+          operand: B,
+          dOuter: "\(dOuterVal)",
+          seqOffset: traversalOffset,
+          seqDim: traversalDim,
+          blockSeq: blockT,
+          blockHead: UInt16(regSize),
+          D: D,
+          leadingDim: leadingDimB,
+          leadingBlockDim: leadingBlockDimB,
+          memPrec: memB,
+          transposed: transposedB,
+          tgOffset: tgOffset
+        )
+      }
+
+      // Inner multiply: for each k step in traversal
+      let kSteps = Int(blockT / 8)
+
+      // Multiply P * V for each head block and traversal step
+      let needsHeadMaskB = D < paddedD
+      let dSteps = Int(regSize / 8)
+      for k in 0..<kSteps {
+        let kOff = k * 8
+
+        for d in 0..<dSteps {
+          let dOff = d * 8
+          // Always index by absolute position in the head dimension.
+          // Even when O is "uncached" in the original Metal source sense,
+          // our IR uses oCachedCount SSA accumulators for all head positions.
+          let accIdx = Int(dOuterVal) / 8 + d
+
+          let absHeadOff = Int(dOuterVal) + dOff
+          let bNeedsMask = needsHeadMaskB && absHeadOff + 8 > Int(D)
+
+          // Load V tile from TG for this (k, d) pair.
+          // V = B operand: B[k,j] = V[k,j] where k=traversal, j=head.
+          let vPrefix = "\(ip)v\(k)x\(d)_"
+
+          if needsHeadMaskB && absHeadOff >= Int(D) {
+            // Entire B register is beyond D — zero it
+            ir += "  %\(vPrefix)sram = bitcast \(irVecType(regB)) zeroinitializer to \(irVecType(regB))\n"
+          } else {
+            let loadPrefix = bNeedsMask ? "\(vPrefix)r_" : vPrefix
+            if transposedB {
+              ir += "  %\(loadPrefix)row = add i32 %morton_x, \(dOff)\n"
+              ir += "  %\(loadPrefix)col = add i32 %morton_y, \(kOff)\n"
+            } else {
+              ir += "  %\(loadPrefix)row = add i32 %morton_y, \(kOff)\n"
+              ir += "  %\(loadPrefix)col = add i32 %morton_x, \(dOff)\n"
+            }
+            ir += generateTGLoad(
+              prefix: loadPrefix,
+              tgOffset: tgOffset,
+              rowOffset: "%\(loadPrefix)row",
+              colOffset: "%\(loadPrefix)col",
+              leadingBlockDim: leadingBlockDimB,
+              memPrec: memB,
+              regPrec: regB,
+              transposed: transposedB
+            )
+
+            // Head masking: zero the register if this thread's head position >= D
+            if bNeedsMask {
+              // morton_x * 2 gives the thread's head position within the 8-wide block
+              ir += "  %\(vPrefix)hpos = add i32 %morton_x, \(absHeadOff)\n"
+              ir += "  %\(vPrefix)oob = icmp uge i32 %\(vPrefix)hpos, \(D)\n"
+              ir += "  %\(vPrefix)sram = select i1 %\(vPrefix)oob, \(irVecType(regB)) zeroinitializer, \(irVecType(regB)) %\(loadPrefix)sram\n"
+            }
+          }
+
+          // Load P tile: P_sram[k] (traversal step k)
+          let pName = "%\(aSourcePrefix)_\(kOff / 8)"
+
+          // Each d-accumulator chains independently across k-steps:
+          //   k=0: cNames[accIdx] → c_k0_d{d}
+          //   k>0: c_k{k-1}_d{d} → c_k{k}_d{d}
+          let cInActual: String
+          if k == 0 {
+            cInActual = cNames[accIdx]
+          } else {
+            cInActual = "%\(ip)c\(k-1)d\(d)"
+          }
+          let cOut = "%\(ip)c\(k)d\(d)"
+
+          ir += irMultiplyAccumulateCall(
+            result: cOut,
+            A: (pName, regA),
+            B: ("%\(vPrefix)sram", regB),
+            C: (cInActual, regC)
+          ) + "\n"
+        }
+      }
+
+      // Barrier
+      ir += "  call void @air.wg.barrier(i32 2, i32 1)\n\n"
+
+      // Update accumulator names (always absolute head position)
+      let lastK = kSteps - 1
+      for d in 0..<dSteps {
+        let accIdx = Int(dOuterVal) / 8 + d
+        cNames[accIdx] = "%\(ip)c\(lastK)d\(d)"
+      }
+    }
+
+    var iterIdx = 0
+    var dOuter: UInt32 = 0
+    while dOuter < headLoopFloor {
+      emitHeadIteration(dOuterVal: dOuter, regSize: UInt32(blockH), iterIdx: iterIdx)
+      dOuter += UInt32(blockH)
+      iterIdx += 1
+    }
+    if headLoopFloor < paddedD {
+      emitHeadIteration(dOuterVal: headLoopFloor, regSize: headEdge, iterIdx: iterIdx)
+    }
+
+    // Branch to after-head label (LLVM IR requires explicit terminators)
+    ir += "  br label %\(p)after_head\n"
+    ir += "\(p)after_head:\n"
+
+    // Final names
+    for i in 0..<accCount {
+      ir += "  %\(p)\(C_name)_final_\(i) = bitcast \(irVecType(regC)) \(cNames[i]) to \(irVecType(regC))\n"
+    }
+
+    return ir
+  }
+
+  // MARK: - Cache Load (Q, dO, etc.)
+
+  func generateCacheLoad(
+    operand: AttentionOperand,
+    prefix p: String,
+    parallelDim: UInt32,
+    D: UInt32,
+    paddedD: UInt32,
+    blockP: UInt16, blockH: UInt16,
+    leadingDim: UInt32, leadingBlockDim: UInt32,
+    memPrec: GEMMOperandPrecision, regPrec: GEMMOperandPrecision,
+    transposed: Bool
+  ) -> String {
+    var ir = ""
+    ir += "  ; === Cache load \(operand) directly from device ===\n"
+
+    // Load directly from device memory into registers — no TG, no async copy,
+    // no barriers. Matches reference pattern (preferAsyncCache=false on M1).
+    //
+    // Head dimension masking: each thread's morton_x determines which head
+    // column pair it loads. When morton_x * 2 + headOffset >= D, the load
+    // would access beyond the buffer. We must zero the register in that case.
+    // For non-transposed, the <2 x T> load reads columns [headOffset, headOffset+1].
+    // For transposed, the 2 scalar loads read rows [headOffset, headOffset+1].
+    // In both cases, headOffset = morton_x * 2 + dOuter + kOff (morton_x
+    // contributes ×2 because each thread holds 2 adjacent elements).
+
+    // Head masking: morton_x ∈ {0,2,4,6} directly gives the head column position.
+    let needsHeadMask = D < paddedD
+
+    var dOuter: UInt32 = 0
+    var iterIdx = 0
+    while dOuter < paddedD {
+      let regSize = min(UInt32(blockH), paddedD - dOuter)
+      let ip = "\(p)\(iterIdx)_"
+
+      let kSteps = Int(regSize / 8)
+      for k in 0..<kSteps {
+        let kOff = k * 8
+        let regIdx = Int(dOuter) / 8 + k
+        let lp = "\(ip)k\(k)_"
+
+        // Check at codegen time if this entire k-step is beyond D
+        let headStart = Int(dOuter) + kOff
+        if headStart >= D {
+          // Entire register is beyond D — just zero it
+          ir += "  %\(p)sram_\(regIdx) = bitcast \(irVecType(regPrec)) zeroinitializer to \(irVecType(regPrec))\n"
+          continue
+        }
+
+        if transposed {
+          ir += "  %\(lp)seq = add i32 %clamped_par_off, 0\n"
+          ir += "  %\(lp)head = add i32 %morton_x, \(headStart)\n"
+          ir += generateDeviceLoad(
+            prefix: lp,
+            bufferName: "%\(operand)",
+            seqOffset: "%\(lp)seq",
+            headOffset: "%\(lp)head",
+            leadingDim: leadingDim,
+            memPrec: memPrec,
+            regPrec: regPrec,
+            transposed: true
+          )
+        } else {
+          ir += "  %\(lp)seq = add i32 %clamped_par_off, 0\n"
+          ir += "  %\(lp)head = add i32 %morton_x, \(headStart)\n"
+          ir += generateDeviceLoad(
+            prefix: lp,
+            bufferName: "%\(operand)",
+            seqOffset: "%\(lp)seq",
+            headOffset: "%\(lp)head",
+            leadingDim: leadingDim,
+            memPrec: memPrec,
+            regPrec: regPrec,
+            transposed: false
+          )
+        }
+
+        // Head masking: zero the register if this thread's head position >= D.
+        // headPos = morton_x + headStart. morton_x ∈ {0,2,4,6}.
+        if needsHeadMask && headStart + 8 > D {
+          // Some threads in this k-step may be out of bounds
+          ir += "  %\(lp)hpos = add i32 %morton_x, \(headStart)\n"
+          ir += "  %\(lp)oob = icmp uge i32 %\(lp)hpos, \(D)\n"
+          ir += "  %\(p)sram_\(regIdx) = select i1 %\(lp)oob, \(irVecType(regPrec)) zeroinitializer, \(irVecType(regPrec)) %\(lp)sram\n"
+        } else {
+          ir += "  %\(p)sram_\(regIdx) = bitcast \(irVecType(regPrec)) %\(lp)sram to \(irVecType(regPrec))\n"
+        }
+      }
+
+      dOuter += UInt32(blockH)
+      iterIdx += 1
+    }
+
+    return ir
+  }
+
+  // MARK: - Forward Cleanup
+
+  func generateForwardCleanup(
+    prefix p: String,
+    oCachedCount: Int,
+    blockP: UInt16, blockH: UInt16,
+    D: UInt32, paddedD: UInt32, headEdge: UInt32,
+    headLoopFloor: UInt32,
+    parallelDim: UInt32,
+    regO: GEMMOperandPrecision, memO: GEMMOperandPrecision,
+    memL: GEMMOperandPrecision,
+    leadingDimO: UInt32, leadingBlockDimO: UInt32,
+    transposedO: Bool,
+    cachedO: Bool
+  ) -> String {
+    let elemSizeO = UInt32(memO.size)
+    let elemSizeL = UInt32(memL.size)
+    let tO = irTypeName(regO)
+    var ir = ""
+
+    ir += """
+
+    cleanup:
+      ; === Forward cleanup: O /= l, store O, store L ===
+
+    """
+
+    // O /= l: scale each O accumulator element by 1/l
+    ir += "  %\(p)inv_l = fdiv fast float 1.0, %l_phi\n"
+
+    for i in 0..<oCachedCount {
+      ir += "  %\(p)oe0_\(i) = extractelement \(irVecType(regO)) %o_phi_\(i), i32 0\n"
+      ir += "  %\(p)oe1_\(i) = extractelement \(irVecType(regO)) %o_phi_\(i), i32 1\n"
+      ir += "  %\(p)os0_\(i) = fmul fast float %\(p)oe0_\(i), %\(p)inv_l\n"
+      ir += "  %\(p)os1_\(i) = fmul fast float %\(p)oe1_\(i), %\(p)inv_l\n"
+      ir += "  %\(p)ov0_\(i) = insertelement \(irVecType(regO)) %o_phi_\(i), float %\(p)os0_\(i), i32 0\n"
+      ir += "  %\(p)o_scaled_\(i) = insertelement \(irVecType(regO)) %\(p)ov0_\(i), float %\(p)os1_\(i), i32 1\n"
+    }
+
+    // Store O: cache store (registers → TG → device) for each d_outer block
+    // Use async copy for edge safety
+    var dOuter: UInt32 = 0
+    var iterIdx = 0
+    while dOuter < paddedD {
+      let regSize = min(UInt32(blockH), paddedD - dOuter)
+      let ip = "\(p)\(iterIdx)_"
+      let kSteps = Int(regSize / 8)
+
+      // Store registers to TG
+      ir += "  ; Store O block d_outer=\(dOuter) to TG\n"
+      for k in 0..<kSteps {
+        let kOff = k * 8
+        let regIdx = Int(dOuter) / 8 + k
+        let sp = "\(ip)k\(k)_"
+
+        // Unshuffle from <64 x T> to <2 x T>
+        ir += irShuffleFromVec64(
+          result: "%\(sp)v2", src: "%\(p)o_scaled_\(regIdx)", type: regO
+        ) + "\n"
+
+        // Convert precision if needed
+        let storeVec: String
+        let storeType: String
+        if regO != memO {
+          ir += "  %\(sp)se0 = extractelement <2 x \(tO)> %\(sp)v2, i32 0\n"
+          ir += "  %\(sp)se1 = extractelement <2 x \(tO)> %\(sp)v2, i32 1\n"
+          ir += "  %\(sp)st0 = fptrunc \(tO) %\(sp)se0 to \(irTypeName(memO))\n"
+          ir += "  %\(sp)st1 = fptrunc \(tO) %\(sp)se1 to \(irTypeName(memO))\n"
+          ir += "  %\(sp)sv0 = insertelement <2 x \(irTypeName(memO))> undef, \(irTypeName(memO)) %\(sp)st0, i32 0\n"
+          ir += "  %\(sp)svec = insertelement <2 x \(irTypeName(memO))> %\(sp)sv0, \(irTypeName(memO)) %\(sp)st1, i32 1\n"
+          storeVec = "%\(sp)svec"
+          storeType = irTypeName(memO)
+        } else {
+          storeVec = "%\(sp)v2"
+          storeType = tO
+        }
+
+        // Guard store: only if thread is in bounds
+        ir += "  %\(sp)in_bounds = icmp ult i32 %unsafe_par_off, \(parallelDim)\n"
+        ir += "  br i1 %\(sp)in_bounds, label %\(sp)do_store, label %\(sp)skip_store\n\n"
+        ir += "\(sp)do_store:\n"
+
+        if transposedO {
+          // Transposed: elements 0,1 are at head positions morton_x+kOff and
+          // morton_x+kOff+1 for the same seq row (oig_y). These map to
+          // TG[head0, oig_y] and TG[head1, oig_y] which are non-contiguous.
+          // Must use two scalar stores.
+          let se0: String
+          let se1: String
+          if storeVec.hasSuffix("svec") {
+            se0 = "%\(sp)st0"
+            se1 = "%\(sp)st1"
+          } else {
+            // storeVec is %{sp}v2, extract elements
+            ir += "  %\(sp)se0 = extractelement <2 x \(storeType)> \(storeVec), i32 0\n"
+            ir += "  %\(sp)se1 = extractelement <2 x \(storeType)> \(storeVec), i32 1\n"
+            se0 = "%\(sp)se0"
+            se1 = "%\(sp)se1"
+          }
+          // Element 0 → TG[morton_x + kOff, oig_y]
+          ir += "  %\(sp)tg_row0 = add i32 %morton_x, \(kOff)\n"
+          ir += "  %\(sp)tg_addr0 = mul i32 %\(sp)tg_row0, \(leadingBlockDimO)\n"
+          ir += "  %\(sp)tg_addr0b = add i32 %\(sp)tg_addr0, %oig_y\n"
+          ir += "  %\(sp)tg_byte0 = mul i32 %\(sp)tg_addr0b, \(elemSizeO)\n"
+          ir += "  %\(sp)tg_byte0_64 = zext i32 %\(sp)tg_byte0 to i64\n"
+          ir += "  %\(sp)tg_ptr0 = getelementptr i8, i8 addrspace(3)* %tg_base, i64 %\(sp)tg_byte0_64\n"
+          ir += "  %\(sp)tg_typed0 = bitcast i8 addrspace(3)* %\(sp)tg_ptr0 to \(storeType) addrspace(3)*\n"
+          ir += "  store \(storeType) \(se0), \(storeType) addrspace(3)* %\(sp)tg_typed0\n"
+          // Element 1 → TG[morton_x + kOff + 1, oig_y]
+          ir += "  %\(sp)tg_row1 = add i32 %morton_x, \(kOff + 1)\n"
+          ir += "  %\(sp)tg_addr1 = mul i32 %\(sp)tg_row1, \(leadingBlockDimO)\n"
+          ir += "  %\(sp)tg_addr1b = add i32 %\(sp)tg_addr1, %oig_y\n"
+          ir += "  %\(sp)tg_byte1 = mul i32 %\(sp)tg_addr1b, \(elemSizeO)\n"
+          ir += "  %\(sp)tg_byte1_64 = zext i32 %\(sp)tg_byte1 to i64\n"
+          ir += "  %\(sp)tg_ptr1 = getelementptr i8, i8 addrspace(3)* %tg_base, i64 %\(sp)tg_byte1_64\n"
+          ir += "  %\(sp)tg_typed1 = bitcast i8 addrspace(3)* %\(sp)tg_ptr1 to \(storeType) addrspace(3)*\n"
+          ir += "  store \(storeType) \(se1), \(storeType) addrspace(3)* %\(sp)tg_typed1\n"
+        } else {
+          // Non-transposed: elements 0,1 are at head positions morton_x+kOff
+          // and morton_x+kOff+1, which are contiguous in memory. Use <2 x T> store.
+          ir += "  %\(sp)tg_row = add i32 %oig_y, 0\n"
+          ir += "  %\(sp)tg_addr = mul i32 %\(sp)tg_row, \(leadingBlockDimO)\n"
+          ir += "  %\(sp)tg_col = add i32 %morton_x, \(kOff)\n"
+          ir += "  %\(sp)tg_addr2 = add i32 %\(sp)tg_addr, %\(sp)tg_col\n"
+          ir += "  %\(sp)tg_byte = mul i32 %\(sp)tg_addr2, \(elemSizeO)\n"
+          ir += "  %\(sp)tg_byte64 = zext i32 %\(sp)tg_byte to i64\n"
+          ir += "  %\(sp)tg_ptr = getelementptr i8, i8 addrspace(3)* %tg_base, i64 %\(sp)tg_byte64\n"
+          ir += "  %\(sp)tg_typed = bitcast i8 addrspace(3)* %\(sp)tg_ptr to <2 x \(storeType)> addrspace(3)*\n"
+          ir += "  store <2 x \(storeType)> \(storeVec), <2 x \(storeType)> addrspace(3)* %\(sp)tg_typed\n"
+        }
+
+        ir += "  br label %\(sp)skip_store\n\n"
+        ir += "\(sp)skip_store:\n"
+      }
+
+      ir += "  call void @air.wg.barrier(i32 2, i32 1)\n"
+
+      // Async copy TG → device (gated to sidx==0)
+      let cp = "\(ip)cp_"
+      ir += "  br i1 %is_sidx0, label %\(cp)do, label %\(cp)skip\n\n"
+      ir += "\(cp)do:\n"
+
+      // Device offset: par_group_off * leadingDimO + dOuter (non-transposed)
+      if transposedO {
+        ir += "  %\(cp)dev_row = mul i32 \(dOuter), \(leadingDimO)\n"
+        ir += "  %\(cp)dev_off32 = add i32 %\(cp)dev_row, %par_group_off\n"
+      } else {
+        ir += "  %\(cp)dev_row = mul i32 %par_group_off, \(leadingDimO)\n"
+        ir += "  %\(cp)dev_off32 = add i32 %\(cp)dev_row, \(dOuter)\n"
+      }
+      ir += "  %\(cp)dev_off = zext i32 %\(cp)dev_off32 to i64\n"
+      ir += "  %\(cp)dev_byte = mul i64 %\(cp)dev_off, \(elemSizeO)\n"
+      ir += "  %\(cp)dst_p = getelementptr i8, i8 addrspace(1)* %O, i64 %\(cp)dev_byte\n"
+      ir += "  %\(cp)src_p = getelementptr i8, i8 addrspace(3)* %tg_base, i64 0\n"
+
+      // Tile: min(D - dOuter, blockH) wide, min(parallelDim - par_group_off, blockP) high
+      let dTile = min(UInt32(blockH), D - min(dOuter, D))
+      ir += "  %\(cp)seq_rem = sub i32 \(parallelDim), %par_group_off\n"
+      ir += "  %\(cp)seq_cmp = icmp ult i32 %\(cp)seq_rem, \(blockP)\n"
+      ir += "  %\(cp)seq_tile32 = select i1 %\(cp)seq_cmp, i32 %\(cp)seq_rem, i32 \(blockP)\n"
+      ir += "  %\(cp)seq_tile = zext i32 %\(cp)seq_tile32 to i64\n"
+
+      let dstStride = leadingDimO * elemSizeO
+      let srcStride = leadingBlockDimO * elemSizeO
+
+      let (tileW, tileH): (String, String)
+      if transposedO {
+        // Width = seq elements, Height = D elements
+        ir += "  %\(cp)w_bytes32 = mul i32 %\(cp)seq_tile32, \(elemSizeO)\n"
+        ir += "  %\(cp)w_bytes = zext i32 %\(cp)w_bytes32 to i64\n"
+        tileW = "%\(cp)w_bytes"
+        tileH = "\(dTile)"
+      } else {
+        // Width = D elements, Height = seq elements
+        tileW = "\(dTile * elemSizeO)"
+        tileH = "%\(cp)seq_tile"
+      }
+
+      ir += "  %\(cp)tile_w = insertelement <2 x i64> zeroinitializer, i64 \(tileW), i32 0\n"
+      ir += "  %\(cp)tile = insertelement <2 x i64> %\(cp)tile_w, i64 \(tileH), i32 1\n"
+
+      ir += "  %\(cp)evp = getelementptr [2 x %event_t addrspace(3)*], [2 x %event_t addrspace(3)*]* %ev, i64 0, i64 0\n"
+      ir += """
+        %\(cp)ev = call %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p1i8.p3i8(
+          i64 1, i64 1,
+          i8 addrspace(1)* %\(cp)dst_p, i64 \(dstStride), i64 1, <2 x i64> %\(cp)tile,
+          i8 addrspace(3)* %\(cp)src_p, i64 \(srcStride), i64 1, <2 x i64> %\(cp)tile,
+          <2 x i64> zeroinitializer, i32 0
+        )
+        store %event_t addrspace(3)* %\(cp)ev, %event_t addrspace(3)** %\(cp)evp
+        call void @air.wait_simdgroup_events(i32 1, %event_t addrspace(3)** %\(cp)evp)
+
+      """
+
+      ir += "  br label %\(cp)skip\n\n"
+      ir += "\(cp)skip:\n"
+      ir += "  call void @air.wg.barrier(i32 2, i32 1)\n\n"
+
+      dOuter += UInt32(blockH)
+      iterIdx += 1
+    }
+
+    // Store L = m + log2(l) (per-thread scalar, one per parallelization element)
+    ir += "  ; Store L\n"
+    ir += "  %\(p)L_in_bounds = icmp ult i32 %unsafe_par_off, \(parallelDim)\n"
+    ir += "  br i1 %\(p)L_in_bounds, label %\(p)store_L, label %\(p)skip_L\n\n"
+
+    ir += "\(p)store_L:\n"
+    ir += irLog2Call(result: "%\(p)log2_l", value: "%l_phi") + "\n"
+    ir += "  %\(p)L_val = fadd fast float %m_phi, %\(p)log2_l\n"
+
+    // Address: L_buf + clamped_par_off * elemSizeL
+    ir += "  %\(p)L_off = zext i32 %clamped_par_off to i64\n"
+    ir += "  %\(p)L_byte = mul i64 %\(p)L_off, \(elemSizeL)\n"
+    ir += "  %\(p)L_ptr = getelementptr i8, i8 addrspace(1)* %L_buf, i64 %\(p)L_byte\n"
+    if memL == .FP32 {
+      ir += "  %\(p)L_typed = bitcast i8 addrspace(1)* %\(p)L_ptr to float addrspace(1)*\n"
+      ir += "  store float %\(p)L_val, float addrspace(1)* %\(p)L_typed\n"
+    } else {
+      // Truncate to memL precision before storing
+      let tL = irTypeName(memL)
+      ir += "  %\(p)L_trunc = fptrunc float %\(p)L_val to \(tL)\n"
+      ir += "  %\(p)L_typed = bitcast i8 addrspace(1)* %\(p)L_ptr to \(tL) addrspace(1)*\n"
+      ir += "  store \(tL) %\(p)L_trunc, \(tL) addrspace(1)* %\(p)L_typed\n"
+    }
+    ir += "  br label %\(p)skip_L\n\n"
+
+    ir += "\(p)skip_L:\n"
+    ir += "  br label %exit\n"
+
+    return ir
+  }
+
+  // MARK: - Softmax from stored L (backward)
+
+  /// P = exp2(S * scaleFactor - L) where L is a per-row scalar (same for all traversal positions).
+  /// Used in backwardQuery where L was stored during the forward pass.
+  func generateSoftmaxFromL(
+    prefix p: String,
+    sSramCount: Int,
+    regS: GEMMOperandPrecision, regP: GEMMOperandPrecision,
+    scaleFactor: Float,
+    lScalar: String,  // SSA name of the L scalar (float)
+    sSource: String = "s_final"  // SSA prefix for S vectors (e.g., "s_final" → %s_final_0)
+  ) -> String {
+    let tS = irTypeName(regS)
+    let tP = irTypeName(regP)
+    var ir = ""
+
+    ir += "  ; === Softmax from L: P = exp2(S * scale - L) ===\n"
+
+    let scaleHex = "0x\(String(Double(scaleFactor).bitPattern, radix: 16, uppercase: true))"
+
+    for i in 0..<sSramCount {
+      ir += "  %\(p)s0_\(i) = extractelement \(irVecType(regS)) %\(sSource)_\(i), i32 0\n"
+      ir += "  %\(p)s1_\(i) = extractelement \(irVecType(regS)) %\(sSource)_\(i), i32 1\n"
+
+      let s0f = (regS == .FP32) ? "%\(p)s0_\(i)" : "%\(p)s0f_\(i)"
+      let s1f = (regS == .FP32) ? "%\(p)s1_\(i)" : "%\(p)s1f_\(i)"
+      if regS != .FP32 {
+        ir += "  \(s0f) = fpext \(tS) %\(p)s0_\(i) to float\n"
+        ir += "  \(s1f) = fpext \(tS) %\(p)s1_\(i) to float\n"
+      }
+
+      ir += "  %\(p)sc0_\(i) = fmul fast float \(s0f), \(scaleHex)\n"
+      ir += "  %\(p)sh0_\(i) = fsub fast float %\(p)sc0_\(i), \(lScalar)\n"
+      ir += irExp2Call(result: "%\(p)p0f_\(i)", value: "%\(p)sh0_\(i)") + "\n"
+
+      ir += "  %\(p)sc1_\(i) = fmul fast float \(s1f), \(scaleHex)\n"
+      ir += "  %\(p)sh1_\(i) = fsub fast float %\(p)sc1_\(i), \(lScalar)\n"
+      ir += irExp2Call(result: "%\(p)p1f_\(i)", value: "%\(p)sh1_\(i)") + "\n"
+
+      let p0 = (regP == .FP32) ? "%\(p)p0f_\(i)" : "%\(p)p0_\(i)"
+      let p1 = (regP == .FP32) ? "%\(p)p1f_\(i)" : "%\(p)p1_\(i)"
+      if regP != .FP32 {
+        ir += "  \(p0) = fptrunc float %\(p)p0f_\(i) to \(tP)\n"
+        ir += "  \(p1) = fptrunc float %\(p)p1f_\(i) to \(tP)\n"
+      }
+
+      ir += "  %\(p)pv0_\(i) = insertelement \(irVecType(regP)) undef, \(tP) \(p0), i32 0\n"
+      ir += "  %\(p)p_\(i) = insertelement \(irVecType(regP)) %\(p)pv0_\(i), \(tP) \(p1), i32 1\n"
+    }
+
+    return ir
+  }
+
+  /// P = exp2(S * scaleFactor - L) where L is a per-column <2 x float> vector.
+  /// Used in backwardKeyValue where L comes from the traversal dimension.
+  /// The L vector has element 0 for morton_x*2 and element 1 for morton_x*2+1.
+  /// P = exp2(S * scaleFactor - L) where L varies per-column of S^T.
+  /// Used in backwardKeyValue where each sSram tile covers different traversal rows,
+  /// so L must be loaded per-tile from the L buffer.
+  func generateSoftmaxFromLVector(
+    prefix p: String,
+    sSramCount: Int,
+    regS: GEMMOperandPrecision, regP: GEMMOperandPrecision,
+    scaleFactor: Float,
+    lBufferName: String,       // L buffer pointer (e.g., "%L_buf")
+    traversalOffset: String,   // loop variable for traversal offset (e.g., "%bkv_r")
+    traversalDim: UInt32,      // total traversal dimension (R)
+    memL: GEMMOperandPrecision,
+    sSource: String = "s_final"  // SSA prefix for S vectors
+  ) -> String {
+    let tS = irTypeName(regS)
+    let tP = irTypeName(regP)
+    let elemSizeL = UInt32(memL.size)
+    let memTypeL = irTypeName(memL)
+    var ir = ""
+
+    ir += "  ; === Softmax from L vector: P = exp2(S * scale - L) ===\n"
+
+    let scaleHex = "0x\(String(Double(scaleFactor).bitPattern, radix: 16, uppercase: true))"
+
+    for i in 0..<sSramCount {
+      // Load L for this tile's 2 traversal positions per thread
+      // Tile i covers columns i*8..(i+1)*8-1
+      // Thread sees columns: traversalOffset + i*8 + morton_x + {0,1}
+      // (morton_x is already {0,2,4,6}, NOT {0,1,2,3})
+      let tileOff = i * 8
+      ir += "  %\(p)tbase_\(i) = add i32 \(traversalOffset), \(tileOff)\n"
+      for elem in 0..<2 {
+        ir += "  %\(p)mxe_\(i)_\(elem) = add i32 %morton_x, \(elem)\n"
+        ir += "  %\(p)lidx_\(i)_\(elem) = add i32 %\(p)tbase_\(i), %\(p)mxe_\(i)_\(elem)\n"
+        // Clamp to bounds
+        ir += "  %\(p)lcmp_\(i)_\(elem) = icmp ult i32 %\(p)lidx_\(i)_\(elem), \(traversalDim)\n"
+        ir += "  %\(p)lsafe_\(i)_\(elem) = select i1 %\(p)lcmp_\(i)_\(elem), i32 %\(p)lidx_\(i)_\(elem), i32 \(traversalDim - 1)\n"
+        ir += "  %\(p)loff_\(i)_\(elem) = zext i32 %\(p)lsafe_\(i)_\(elem) to i64\n"
+        ir += "  %\(p)lbyte_\(i)_\(elem) = mul i64 %\(p)loff_\(i)_\(elem), \(elemSizeL)\n"
+        ir += "  %\(p)lptr_\(i)_\(elem) = getelementptr i8, i8 addrspace(1)* \(lBufferName), i64 %\(p)lbyte_\(i)_\(elem)\n"
+        ir += "  %\(p)ltyped_\(i)_\(elem) = bitcast i8 addrspace(1)* %\(p)lptr_\(i)_\(elem) to \(memTypeL) addrspace(1)*\n"
+        ir += "  %\(p)lraw_\(i)_\(elem) = load \(memTypeL), \(memTypeL) addrspace(1)* %\(p)ltyped_\(i)_\(elem)\n"
+        if memL != .FP32 {
+          ir += "  %\(p)L\(elem)_\(i) = fpext \(memTypeL) %\(p)lraw_\(i)_\(elem) to float\n"
+        } else {
+          ir += "  %\(p)L\(elem)_\(i) = bitcast float %\(p)lraw_\(i)_\(elem) to float\n"
+        }
+      }
+
+      ir += "  %\(p)s0_\(i) = extractelement \(irVecType(regS)) %\(sSource)_\(i), i32 0\n"
+      ir += "  %\(p)s1_\(i) = extractelement \(irVecType(regS)) %\(sSource)_\(i), i32 1\n"
+
+      let s0f = (regS == .FP32) ? "%\(p)s0_\(i)" : "%\(p)s0f_\(i)"
+      let s1f = (regS == .FP32) ? "%\(p)s1_\(i)" : "%\(p)s1f_\(i)"
+      if regS != .FP32 {
+        ir += "  \(s0f) = fpext \(tS) %\(p)s0_\(i) to float\n"
+        ir += "  \(s1f) = fpext \(tS) %\(p)s1_\(i) to float\n"
+      }
+
+      // P = exp2(S * scale - L)
+      // Each tile loads its own L values for the traversal positions it covers
+      ir += "  %\(p)sc0_\(i) = fmul fast float \(s0f), \(scaleHex)\n"
+      ir += "  %\(p)sh0_\(i) = fsub fast float %\(p)sc0_\(i), %\(p)L0_\(i)\n"
+      ir += irExp2Call(result: "%\(p)p0f_\(i)", value: "%\(p)sh0_\(i)") + "\n"
+
+      ir += "  %\(p)sc1_\(i) = fmul fast float \(s1f), \(scaleHex)\n"
+      ir += "  %\(p)sh1_\(i) = fsub fast float %\(p)sc1_\(i), %\(p)L1_\(i)\n"
+      ir += irExp2Call(result: "%\(p)p1f_\(i)", value: "%\(p)sh1_\(i)") + "\n"
+
+      let p0 = (regP == .FP32) ? "%\(p)p0f_\(i)" : "%\(p)p0_\(i)"
+      let p1 = (regP == .FP32) ? "%\(p)p1f_\(i)" : "%\(p)p1_\(i)"
+      if regP != .FP32 {
+        ir += "  \(p0) = fptrunc float %\(p)p0f_\(i) to \(tP)\n"
+        ir += "  \(p1) = fptrunc float %\(p)p1f_\(i) to \(tP)\n"
+      }
+
+      ir += "  %\(p)pv0_\(i) = insertelement \(irVecType(regP)) undef, \(tP) \(p0), i32 0\n"
+      ir += "  %\(p)p_\(i) = insertelement \(irVecType(regP)) %\(p)pv0_\(i), \(tP) \(p1), i32 1\n"
+    }
+
+    return ir
+  }
+
+  // MARK: - Derivative Softmax (backward)
+
+  /// dS = P * (dP - D_scalar) * derivScale
+  /// Used in backwardQuery where D is a per-row scalar (same for all traversal positions).
+  func generateDerivativeSoftmax(
+    prefix p: String,
+    sSramCount: Int,
+    regP: GEMMOperandPrecision, regdP: GEMMOperandPrecision,
+    regdS: GEMMOperandPrecision,
+    derivScale: Float,
+    dScalar: String,  // SSA name of D scalar (float)
+    pSource: String,  // SSA prefix for P vectors (e.g., "bq_sf_p" → %bq_sf_p_0)
+    dpSource: String  // SSA prefix for dP vectors (e.g., "dp_final" → %dp_final_0)
+  ) -> String {
+    let tP = irTypeName(regP)
+    let tdP = irTypeName(regdP)
+    let tdS = irTypeName(regdS)
+    var ir = ""
+
+    ir += "  ; === Derivative softmax: dS = P * (dP - D) * scale ===\n"
+
+    let scaleHex = "0x\(String(Double(derivScale).bitPattern, radix: 16, uppercase: true))"
+
+    for i in 0..<sSramCount {
+      // Extract P elements
+      ir += "  %\(p)p0_\(i) = extractelement \(irVecType(regP)) %\(pSource)_\(i), i32 0\n"
+      ir += "  %\(p)p1_\(i) = extractelement \(irVecType(regP)) %\(pSource)_\(i), i32 1\n"
+
+      // Extract dP elements
+      ir += "  %\(p)dp0_\(i) = extractelement \(irVecType(regdP)) %\(dpSource)_\(i), i32 0\n"
+      ir += "  %\(p)dp1_\(i) = extractelement \(irVecType(regdP)) %\(dpSource)_\(i), i32 1\n"
+
+      // Convert to float
+      let p0f = (regP == .FP32) ? "%\(p)p0_\(i)" : "%\(p)p0f_\(i)"
+      let p1f = (regP == .FP32) ? "%\(p)p1_\(i)" : "%\(p)p1f_\(i)"
+      let dp0f = (regdP == .FP32) ? "%\(p)dp0_\(i)" : "%\(p)dp0f_\(i)"
+      let dp1f = (regdP == .FP32) ? "%\(p)dp1_\(i)" : "%\(p)dp1f_\(i)"
+      if regP != .FP32 {
+        ir += "  \(p0f) = fpext \(tP) %\(p)p0_\(i) to float\n"
+        ir += "  \(p1f) = fpext \(tP) %\(p)p1_\(i) to float\n"
+      }
+      if regdP != .FP32 {
+        ir += "  \(dp0f) = fpext \(tdP) %\(p)dp0_\(i) to float\n"
+        ir += "  \(dp1f) = fpext \(tdP) %\(p)dp1_\(i) to float\n"
+      }
+
+      // dS = P * (dP - D) * derivScale
+      ir += "  %\(p)sub0_\(i) = fsub fast float \(dp0f), \(dScalar)\n"
+      ir += "  %\(p)pds0_\(i) = fmul fast float \(p0f), %\(p)sub0_\(i)\n"
+      ir += "  %\(p)ds0f_\(i) = fmul fast float %\(p)pds0_\(i), \(scaleHex)\n"
+
+      ir += "  %\(p)sub1_\(i) = fsub fast float \(dp1f), \(dScalar)\n"
+      ir += "  %\(p)pds1_\(i) = fmul fast float \(p1f), %\(p)sub1_\(i)\n"
+      ir += "  %\(p)ds1f_\(i) = fmul fast float %\(p)pds1_\(i), \(scaleHex)\n"
+
+      // Convert to dS precision and construct <64 x T>
+      let ds0 = (regdS == .FP32) ? "%\(p)ds0f_\(i)" : "%\(p)ds0_\(i)"
+      let ds1 = (regdS == .FP32) ? "%\(p)ds1f_\(i)" : "%\(p)ds1_\(i)"
+      if regdS != .FP32 {
+        ir += "  \(ds0) = fptrunc float %\(p)ds0f_\(i) to \(tdS)\n"
+        ir += "  \(ds1) = fptrunc float %\(p)ds1f_\(i) to \(tdS)\n"
+      }
+
+      ir += "  %\(p)dsv0_\(i) = insertelement \(irVecType(regdS)) undef, \(tdS) \(ds0), i32 0\n"
+      ir += "  %\(p)ds_\(i) = insertelement \(irVecType(regdS)) %\(p)dsv0_\(i), \(tdS) \(ds1), i32 1\n"
+    }
+
+    return ir
+  }
+
+  /// dS = P * (dP * derivScale - D_stored)
+  /// Used in backwardKeyValue where D varies per-column of S^T.
+  /// D_stored is already pre-scaled (D_raw * derivScale) from the bwd_q kernel.
+  /// Each sSram tile i covers traversal columns i*8..(i+1)*8-1, so each tile
+  /// needs different D values loaded from the D buffer.
+  func generateDerivativeSoftmaxVector(
+    prefix p: String,
+    sSramCount: Int,
+    regP: GEMMOperandPrecision, regdP: GEMMOperandPrecision,
+    regdS: GEMMOperandPrecision,
+    derivScale: Float,
+    dBufferName: String,       // D buffer pointer (e.g., "%D_buf")
+    traversalOffset: String,   // loop variable for traversal offset (e.g., "%bkv_r")
+    traversalDim: UInt32,      // total traversal dimension (R)
+    memD: GEMMOperandPrecision,
+    pSource: String,  // SSA prefix for P vectors (e.g., "bkv_sf_p" → %bkv_sf_p_0)
+    dpSource: String  // SSA prefix for dP vectors (e.g., "dp_final" → %dp_final_0)
+  ) -> String {
+    let tP = irTypeName(regP)
+    let tdP = irTypeName(regdP)
+    let tdS = irTypeName(regdS)
+    let elemSizeD = UInt32(memD.size)
+    let memTypeD = irTypeName(memD)
+    var ir = ""
+
+    ir += "  ; === Derivative softmax vector: dS = P * (dP * scale - D_stored) ===\n"
+
+    let scaleHex = "0x\(String(Double(derivScale).bitPattern, radix: 16, uppercase: true))"
+
+    for i in 0..<sSramCount {
+      // Load D for this tile's 2 traversal positions per thread
+      // Tile i covers columns i*8..(i+1)*8-1
+      // Thread sees columns: traversalOffset + i*8 + morton_x + {0,1}
+      // (morton_x is already {0,2,4,6}, NOT {0,1,2,3})
+      let tileOff = i * 8
+      ir += "  %\(p)tbase_\(i) = add i32 \(traversalOffset), \(tileOff)\n"
+      for elem in 0..<2 {
+        ir += "  %\(p)mxe_\(i)_\(elem) = add i32 %morton_x, \(elem)\n"
+        ir += "  %\(p)didx_\(i)_\(elem) = add i32 %\(p)tbase_\(i), %\(p)mxe_\(i)_\(elem)\n"
+        // Clamp to bounds
+        ir += "  %\(p)dcmp_\(i)_\(elem) = icmp ult i32 %\(p)didx_\(i)_\(elem), \(traversalDim)\n"
+        ir += "  %\(p)dsafe_\(i)_\(elem) = select i1 %\(p)dcmp_\(i)_\(elem), i32 %\(p)didx_\(i)_\(elem), i32 \(traversalDim - 1)\n"
+        ir += "  %\(p)doff_\(i)_\(elem) = zext i32 %\(p)dsafe_\(i)_\(elem) to i64\n"
+        ir += "  %\(p)dbyte_\(i)_\(elem) = mul i64 %\(p)doff_\(i)_\(elem), \(elemSizeD)\n"
+        ir += "  %\(p)dptr_\(i)_\(elem) = getelementptr i8, i8 addrspace(1)* \(dBufferName), i64 %\(p)dbyte_\(i)_\(elem)\n"
+        ir += "  %\(p)dtyped_\(i)_\(elem) = bitcast i8 addrspace(1)* %\(p)dptr_\(i)_\(elem) to \(memTypeD) addrspace(1)*\n"
+        ir += "  %\(p)draw_\(i)_\(elem) = load \(memTypeD), \(memTypeD) addrspace(1)* %\(p)dtyped_\(i)_\(elem)\n"
+        if memD != .FP32 {
+          ir += "  %\(p)D\(elem)_\(i) = fpext \(memTypeD) %\(p)draw_\(i)_\(elem) to float\n"
+        } else {
+          ir += "  %\(p)D\(elem)_\(i) = bitcast float %\(p)draw_\(i)_\(elem) to float\n"
+        }
+      }
+
+      ir += "  %\(p)p0_\(i) = extractelement \(irVecType(regP)) %\(pSource)_\(i), i32 0\n"
+      ir += "  %\(p)p1_\(i) = extractelement \(irVecType(regP)) %\(pSource)_\(i), i32 1\n"
+
+      ir += "  %\(p)dp0_\(i) = extractelement \(irVecType(regdP)) %\(dpSource)_\(i), i32 0\n"
+      ir += "  %\(p)dp1_\(i) = extractelement \(irVecType(regdP)) %\(dpSource)_\(i), i32 1\n"
+
+      let p0f = (regP == .FP32) ? "%\(p)p0_\(i)" : "%\(p)p0f_\(i)"
+      let p1f = (regP == .FP32) ? "%\(p)p1_\(i)" : "%\(p)p1f_\(i)"
+      let dp0f = (regdP == .FP32) ? "%\(p)dp0_\(i)" : "%\(p)dp0f_\(i)"
+      let dp1f = (regdP == .FP32) ? "%\(p)dp1_\(i)" : "%\(p)dp1f_\(i)"
+      if regP != .FP32 {
+        ir += "  \(p0f) = fpext \(tP) %\(p)p0_\(i) to float\n"
+        ir += "  \(p1f) = fpext \(tP) %\(p)p1_\(i) to float\n"
+      }
+      if regdP != .FP32 {
+        ir += "  \(dp0f) = fpext \(tdP) %\(p)dp0_\(i) to float\n"
+        ir += "  \(dp1f) = fpext \(tdP) %\(p)dp1_\(i) to float\n"
+      }
+
+      // dS = P * (dP * scale - D_stored)
+      // D_stored is already D_raw * derivScale, so scale dP to match
+      ir += "  %\(p)sdp0_\(i) = fmul fast float \(dp0f), \(scaleHex)\n"
+      ir += "  %\(p)sub0_\(i) = fsub fast float %\(p)sdp0_\(i), %\(p)D0_\(i)\n"
+      ir += "  %\(p)ds0f_\(i) = fmul fast float \(p0f), %\(p)sub0_\(i)\n"
+
+      ir += "  %\(p)sdp1_\(i) = fmul fast float \(dp1f), \(scaleHex)\n"
+      ir += "  %\(p)sub1_\(i) = fsub fast float %\(p)sdp1_\(i), %\(p)D1_\(i)\n"
+      ir += "  %\(p)ds1f_\(i) = fmul fast float \(p1f), %\(p)sub1_\(i)\n"
+
+      let ds0 = (regdS == .FP32) ? "%\(p)ds0f_\(i)" : "%\(p)ds0_\(i)"
+      let ds1 = (regdS == .FP32) ? "%\(p)ds1f_\(i)" : "%\(p)ds1_\(i)"
+      if regdS != .FP32 {
+        ir += "  \(ds0) = fptrunc float %\(p)ds0f_\(i) to \(tdS)\n"
+        ir += "  \(ds1) = fptrunc float %\(p)ds1f_\(i) to \(tdS)\n"
+      }
+
+      ir += "  %\(p)dsv0_\(i) = insertelement \(irVecType(regdS)) undef, \(tdS) \(ds0), i32 0\n"
+      ir += "  %\(p)ds_\(i) = insertelement \(irVecType(regdS)) %\(p)dsv0_\(i), \(tdS) \(ds1), i32 1\n"
+    }
+
+    return ir
+  }
+
+  // MARK: - Compute D = sum(dO * O)
+
+  /// Compute D = reduce_sum(dO[row,:] * O[row,:])
+  /// Both dO and O are loaded from device (or dO from cache).
+  /// Result: %D_sram (float scalar per thread, reduced across head dim).
+  func generateComputeD(
+    prefix p: String,
+    D: UInt32, paddedD: UInt32, blockH: UInt16,
+    headLoopFloor: UInt32, headEdge: UInt32,
+    parallelDim: UInt32,
+    cachedO: Bool, cacheddO: Bool,
+    leadingDimO: UInt32, leadingDimdO: UInt32,
+    memO: GEMMOperandPrecision, regO: GEMMOperandPrecision,
+    memdO: GEMMOperandPrecision, regdO: GEMMOperandPrecision,
+    transposedO: Bool, transposeddO: Bool
+  ) -> String {
+    var ir = ""
+    ir += "  ; === Compute D = sum(dO * O) ===\n"
+
+    // Accumulate dO * O elementwise across the head dimension
+    ir += "  ; D_acc = sum over d of (dO[row,d] * O[row,d])\n"
+
+    var accName = "0.0"  // running float accumulator for element 0+1
+
+    var dOuter: UInt32 = 0
+    var iterIdx = 0
+    while dOuter < paddedD {
+      let regSize = min(UInt32(blockH), paddedD - dOuter)
+      let kSteps = Int(regSize / 8)
+
+      for k in 0..<kSteps {
+        let kOff = k * 8
+        let headStart = Int(dOuter) + kOff
+        let ip = "\(p)\(iterIdx)k\(k)_"
+
+        // Skip if beyond D
+        if headStart >= D {
+          continue
+        }
+
+        // Load O from device
+        ir += "  %\(ip)o_seq = add i32 %clamped_par_off, 0\n"
+        ir += "  %\(ip)o_head = add i32 %morton_x, \(headStart)\n"
+        ir += generateDeviceLoad(
+          prefix: "\(ip)o_",
+          bufferName: "%O",
+          seqOffset: "%\(ip)o_seq",
+          headOffset: "%\(ip)o_head",
+          leadingDim: leadingDimO,
+          memPrec: memO,
+          regPrec: regO,
+          transposed: transposedO
+        )
+
+        // Load dO from cache or device
+        if cacheddO {
+          let cacheIdx = Int(dOuter) / 8 + k
+          ir += "  %\(ip)do_sram = bitcast \(irVecType(regdO)) %cdo_sram_\(cacheIdx) to \(irVecType(regdO))\n"
+        } else {
+          ir += "  %\(ip)do_seq = add i32 %clamped_par_off, 0\n"
+          ir += "  %\(ip)do_head = add i32 %morton_x, \(headStart)\n"
+          ir += generateDeviceLoad(
+            prefix: "\(ip)do_",
+            bufferName: "%dO",
+            seqOffset: "%\(ip)do_seq",
+            headOffset: "%\(ip)do_head",
+            leadingDim: leadingDimdO,
+            memPrec: memdO,
+            regPrec: regdO,
+            transposed: transposeddO
+          )
+        }
+
+        // Extract elements and multiply
+        ir += "  %\(ip)o0 = extractelement \(irVecType(regO)) %\(ip)o_sram, i32 0\n"
+        ir += "  %\(ip)o1 = extractelement \(irVecType(regO)) %\(ip)o_sram, i32 1\n"
+        ir += "  %\(ip)do0 = extractelement \(irVecType(regdO)) %\(ip)do_sram, i32 0\n"
+        ir += "  %\(ip)do1 = extractelement \(irVecType(regdO)) %\(ip)do_sram, i32 1\n"
+
+        // Convert to float if needed
+        let o0f = (regO == .FP32) ? "%\(ip)o0" : "%\(ip)o0f"
+        let o1f = (regO == .FP32) ? "%\(ip)o1" : "%\(ip)o1f"
+        let do0f = (regdO == .FP32) ? "%\(ip)do0" : "%\(ip)do0f"
+        let do1f = (regdO == .FP32) ? "%\(ip)do1" : "%\(ip)do1f"
+        if regO != .FP32 {
+          ir += "  \(o0f) = fpext \(irTypeName(regO)) %\(ip)o0 to float\n"
+          ir += "  \(o1f) = fpext \(irTypeName(regO)) %\(ip)o1 to float\n"
+        }
+        if regdO != .FP32 {
+          ir += "  \(do0f) = fpext \(irTypeName(regdO)) %\(ip)do0 to float\n"
+          ir += "  \(do1f) = fpext \(irTypeName(regdO)) %\(ip)do1 to float\n"
+        }
+
+        // Multiply and accumulate
+        ir += "  %\(ip)prod0_raw = fmul fast float \(do0f), \(o0f)\n"
+        ir += "  %\(ip)prod1_raw = fmul fast float \(do1f), \(o1f)\n"
+
+        // Head masking: zero products for threads whose head position >= D
+        // Device load gives positions [morton_x + headStart, morton_x + headStart + 1]
+        // morton_x is always even (0, 2, 4, 6, ...), so element 0 is at
+        // morton_x + headStart, element 1 is at morton_x + headStart + 1.
+        if headStart + 8 > Int(D) {
+          ir += "  %\(ip)hpos0 = add i32 %morton_x, \(headStart)\n"
+          ir += "  %\(ip)hpos1 = add i32 %morton_x, \(headStart + 1)\n"
+          ir += "  %\(ip)oob0 = icmp uge i32 %\(ip)hpos0, \(D)\n"
+          ir += "  %\(ip)oob1 = icmp uge i32 %\(ip)hpos1, \(D)\n"
+          ir += "  %\(ip)prod0 = select i1 %\(ip)oob0, float 0.0, float %\(ip)prod0_raw\n"
+          ir += "  %\(ip)prod1 = select i1 %\(ip)oob1, float 0.0, float %\(ip)prod1_raw\n"
+        } else {
+          ir += "  %\(ip)prod0 = bitcast float %\(ip)prod0_raw to float\n"
+          ir += "  %\(ip)prod1 = bitcast float %\(ip)prod1_raw to float\n"
+        }
+
+        ir += "  %\(ip)sum01 = fadd fast float %\(ip)prod0, %\(ip)prod1\n"
+        ir += "  %\(ip)acc = fadd fast float \(accName), %\(ip)sum01\n"
+        accName = "%\(ip)acc"
+      }
+
+      dOuter += UInt32(blockH)
+      iterIdx += 1
+    }
+
+    // If no iterations happened (D=0?), set to 0
+    if accName == "0.0" {
+      ir += "  %\(p)final_acc = bitcast float 0.0 to float\n"
+      accName = "%\(p)final_acc"
+    }
+
+    // SIMD reduction: shuffle_xor with masks 1 and 8
+    ir += irShuffleXorCall(result: "%\(p)shuf1", value: accName, mask: 1) + "\n"
+    ir += "  %\(p)sum_s1 = fadd fast float \(accName), %\(p)shuf1\n"
+    ir += irShuffleXorCall(result: "%\(p)shuf8", value: "%\(p)sum_s1", mask: 8) + "\n"
+    ir += "  %\(p)sum_s8 = fadd fast float %\(p)sum_s1, %\(p)shuf8\n"
+
+    // D_sram = raw sum(dO * O) — no scaling here.
+    // The derivative softmax formula dS = P * (dP * derivScale - D) handles
+    // the scale factor on dP, not on D.
+    ir += "  %D_sram = bitcast float %\(p)sum_s8 to float\n"
+
+    return ir
+  }
+
+  // MARK: - Load Traversal Scalar (L or D for bkv)
+
+  /// Load a per-row scalar from device memory for each thread's traversal position.
+  /// In bkv, the traversal dimension is R, so we load L[r + morton_x*2] and L[r + morton_x*2+1].
+  /// Result: a <2 x float> with one L/D value per thread element.
+  func generateLoadTraversalScalar(
+    prefix p: String,
+    bufferName: String,
+    resultName: String,
+    traversalOffset: String,
+    traversalDim: UInt32,
+    blockT: UInt16,
+    memPrec: GEMMOperandPrecision
+  ) -> String {
+    let elemSize = UInt32(memPrec.size)
+    let memType = irTypeName(memPrec)
+    var ir = ""
+
+    ir += "  ; === Load traversal scalar from \(bufferName) ===\n"
+
+    // Each thread loads 2 scalar values for its morton_x positions.
+    // Thread position in traversal = traversalOffset + morton_x + {0, 1}
+    // (morton_x is already {0,2,4,6}, NOT {0,1,2,3})
+    for elem in 0..<2 {
+      ir += "  %\(p)mx_\(elem) = add i32 %morton_x, \(elem)\n"
+      ir += "  %\(p)idx_\(elem) = add i32 \(traversalOffset), %\(p)mx_\(elem)\n"
+
+      // Clamp to bounds
+      ir += "  %\(p)cmp_\(elem) = icmp ult i32 %\(p)idx_\(elem), \(traversalDim)\n"
+      ir += "  %\(p)dim_m1_\(elem) = sub i32 \(traversalDim), 1\n"
+      ir += "  %\(p)safe_\(elem) = select i1 %\(p)cmp_\(elem), i32 %\(p)idx_\(elem), i32 %\(p)dim_m1_\(elem)\n"
+
+      ir += "  %\(p)off64_\(elem) = zext i32 %\(p)safe_\(elem) to i64\n"
+      ir += "  %\(p)byte_\(elem) = mul i64 %\(p)off64_\(elem), \(elemSize)\n"
+      ir += "  %\(p)ptr_\(elem) = getelementptr i8, i8 addrspace(1)* \(bufferName), i64 %\(p)byte_\(elem)\n"
+      ir += "  %\(p)typed_\(elem) = bitcast i8 addrspace(1)* %\(p)ptr_\(elem) to \(memType) addrspace(1)*\n"
+      ir += "  %\(p)raw_\(elem) = load \(memType), \(memType) addrspace(1)* %\(p)typed_\(elem)\n"
+
+      if memPrec != .FP32 {
+        ir += "  %\(p)val_\(elem) = fpext \(memType) %\(p)raw_\(elem) to float\n"
+      } else {
+        ir += "  %\(p)val_\(elem) = bitcast float %\(p)raw_\(elem) to float\n"
+      }
+    }
+
+    // Construct <2 x float>
+    ir += "  %\(p)v0 = insertelement <2 x float> undef, float %\(p)val_0, i32 0\n"
+    ir += "  \(resultName) = insertelement <2 x float> %\(p)v0, float %\(p)val_1, i32 1\n"
+
+    return ir
+  }
+
+  // MARK: - Cache Store (registers → TG → device)
+
+  /// Store cached registers to device memory via TG + async copy.
+  /// Same pattern as generateForwardCleanup O store, but parameterized.
+  func generateCacheStore(
+    operand: AttentionOperand,
+    prefix p: String,
+    regCount: Int,
+    blockP: UInt16, blockH: UInt16,
+    D: UInt32, paddedD: UInt32, headEdge: UInt32,
+    headLoopFloor: UInt32,
+    parallelDim: UInt32,
+    regPrec: GEMMOperandPrecision, memPrec: GEMMOperandPrecision,
+    leadingDim: UInt32, leadingBlockDim: UInt32,
+    transposed: Bool,
+    phiPrefix: String  // prefix for the phi name of the accumulators (e.g., "dq_phi")
+  ) -> String {
+    let elemSize = UInt32(memPrec.size)
+    let tReg = irTypeName(regPrec)
+    var ir = ""
+
+    ir += "  ; === Cache store \(operand) ===\n"
+
+    var dOuter: UInt32 = 0
+    var iterIdx = 0
+    while dOuter < paddedD {
+      let regSize = min(UInt32(blockH), paddedD - dOuter)
+      let ip = "\(p)\(iterIdx)_"
+      let kSteps = Int(regSize / 8)
+
+      // Store registers to TG
+      for k in 0..<kSteps {
+        let kOff = k * 8
+        let regIdx = Int(dOuter) / 8 + k
+        let sp = "\(ip)k\(k)_"
+
+        // Unshuffle from <64 x T> to <2 x T>
+        ir += irShuffleFromVec64(
+          result: "%\(sp)v2", src: "%\(phiPrefix)_\(regIdx)", type: regPrec
+        ) + "\n"
+
+        // Convert precision if needed
+        let storeVec: String
+        let storeType: String
+        if regPrec != memPrec {
+          let memT = irTypeName(memPrec)
+          ir += "  %\(sp)se0 = extractelement <2 x \(tReg)> %\(sp)v2, i32 0\n"
+          ir += "  %\(sp)se1 = extractelement <2 x \(tReg)> %\(sp)v2, i32 1\n"
+          ir += "  %\(sp)st0 = fptrunc \(tReg) %\(sp)se0 to \(memT)\n"
+          ir += "  %\(sp)st1 = fptrunc \(tReg) %\(sp)se1 to \(memT)\n"
+          ir += "  %\(sp)sv0 = insertelement <2 x \(memT)> undef, \(memT) %\(sp)st0, i32 0\n"
+          ir += "  %\(sp)svec = insertelement <2 x \(memT)> %\(sp)sv0, \(memT) %\(sp)st1, i32 1\n"
+          storeVec = "%\(sp)svec"
+          storeType = memT
+        } else {
+          storeVec = "%\(sp)v2"
+          storeType = tReg
+        }
+
+        ir += "  %\(sp)in_bounds = icmp ult i32 %unsafe_par_off, \(parallelDim)\n"
+        ir += "  br i1 %\(sp)in_bounds, label %\(sp)do_store, label %\(sp)skip_store\n\n"
+        ir += "\(sp)do_store:\n"
+
+        if transposed {
+          // Transposed: elements 0,1 are at head positions morton_x+kOff and
+          // morton_x+kOff+1 for the same seq row (oig_y). In TG[head, seq],
+          // these map to non-contiguous addresses. Use two scalar stores.
+          let se0: String
+          let se1: String
+          if storeVec.hasSuffix("svec") {
+            se0 = "%\(sp)st0"
+            se1 = "%\(sp)st1"
+          } else {
+            ir += "  %\(sp)se0 = extractelement <2 x \(storeType)> \(storeVec), i32 0\n"
+            ir += "  %\(sp)se1 = extractelement <2 x \(storeType)> \(storeVec), i32 1\n"
+            se0 = "%\(sp)se0"
+            se1 = "%\(sp)se1"
+          }
+          ir += "  %\(sp)tg_row0 = add i32 %morton_x, \(kOff)\n"
+          ir += "  %\(sp)tg_addr0 = mul i32 %\(sp)tg_row0, \(leadingBlockDim)\n"
+          ir += "  %\(sp)tg_addr0b = add i32 %\(sp)tg_addr0, %oig_y\n"
+          ir += "  %\(sp)tg_byte0 = mul i32 %\(sp)tg_addr0b, \(elemSize)\n"
+          ir += "  %\(sp)tg_byte0_64 = zext i32 %\(sp)tg_byte0 to i64\n"
+          ir += "  %\(sp)tg_ptr0 = getelementptr i8, i8 addrspace(3)* %tg_base, i64 %\(sp)tg_byte0_64\n"
+          ir += "  %\(sp)tg_typed0 = bitcast i8 addrspace(3)* %\(sp)tg_ptr0 to \(storeType) addrspace(3)*\n"
+          ir += "  store \(storeType) \(se0), \(storeType) addrspace(3)* %\(sp)tg_typed0\n"
+          ir += "  %\(sp)tg_row1 = add i32 %morton_x, \(kOff + 1)\n"
+          ir += "  %\(sp)tg_addr1 = mul i32 %\(sp)tg_row1, \(leadingBlockDim)\n"
+          ir += "  %\(sp)tg_addr1b = add i32 %\(sp)tg_addr1, %oig_y\n"
+          ir += "  %\(sp)tg_byte1 = mul i32 %\(sp)tg_addr1b, \(elemSize)\n"
+          ir += "  %\(sp)tg_byte1_64 = zext i32 %\(sp)tg_byte1 to i64\n"
+          ir += "  %\(sp)tg_ptr1 = getelementptr i8, i8 addrspace(3)* %tg_base, i64 %\(sp)tg_byte1_64\n"
+          ir += "  %\(sp)tg_typed1 = bitcast i8 addrspace(3)* %\(sp)tg_ptr1 to \(storeType) addrspace(3)*\n"
+          ir += "  store \(storeType) \(se1), \(storeType) addrspace(3)* %\(sp)tg_typed1\n"
+        } else {
+          // Non-transposed: elements are at contiguous head positions. Use <2 x T> store.
+          ir += "  %\(sp)tg_row = add i32 %oig_y, 0\n"
+          ir += "  %\(sp)tg_addr = mul i32 %\(sp)tg_row, \(leadingBlockDim)\n"
+          ir += "  %\(sp)tg_col = add i32 %morton_x, \(kOff)\n"
+          ir += "  %\(sp)tg_addr2 = add i32 %\(sp)tg_addr, %\(sp)tg_col\n"
+          ir += "  %\(sp)tg_byte = mul i32 %\(sp)tg_addr2, \(elemSize)\n"
+          ir += "  %\(sp)tg_byte64 = zext i32 %\(sp)tg_byte to i64\n"
+          ir += "  %\(sp)tg_ptr = getelementptr i8, i8 addrspace(3)* %tg_base, i64 %\(sp)tg_byte64\n"
+          ir += "  %\(sp)tg_typed = bitcast i8 addrspace(3)* %\(sp)tg_ptr to <2 x \(storeType)> addrspace(3)*\n"
+          ir += "  store <2 x \(storeType)> \(storeVec), <2 x \(storeType)> addrspace(3)* %\(sp)tg_typed\n"
+        }
+
+        ir += "  br label %\(sp)skip_store\n\n"
+        ir += "\(sp)skip_store:\n"
+      }
+
+      ir += "  call void @air.wg.barrier(i32 2, i32 1)\n"
+
+      // Async copy TG → device
+      let cp = "\(ip)cp_"
+      ir += "  br i1 %is_sidx0, label %\(cp)do, label %\(cp)skip\n\n"
+      ir += "\(cp)do:\n"
+
+      if transposed {
+        ir += "  %\(cp)dev_row = mul i32 \(dOuter), \(leadingDim)\n"
+        ir += "  %\(cp)dev_off32 = add i32 %\(cp)dev_row, %par_group_off\n"
+      } else {
+        ir += "  %\(cp)dev_row = mul i32 %par_group_off, \(leadingDim)\n"
+        ir += "  %\(cp)dev_off32 = add i32 %\(cp)dev_row, \(dOuter)\n"
+      }
+      ir += "  %\(cp)dev_off = zext i32 %\(cp)dev_off32 to i64\n"
+      ir += "  %\(cp)dev_byte = mul i64 %\(cp)dev_off, \(elemSize)\n"
+      ir += "  %\(cp)dst_p = getelementptr i8, i8 addrspace(1)* %\(operand), i64 %\(cp)dev_byte\n"
+      ir += "  %\(cp)src_p = getelementptr i8, i8 addrspace(3)* %tg_base, i64 0\n"
+
+      let dTile = min(UInt32(blockH), D - min(dOuter, D))
+      ir += "  %\(cp)seq_rem = sub i32 \(parallelDim), %par_group_off\n"
+      ir += "  %\(cp)seq_cmp = icmp ult i32 %\(cp)seq_rem, \(blockP)\n"
+      ir += "  %\(cp)seq_tile32 = select i1 %\(cp)seq_cmp, i32 %\(cp)seq_rem, i32 \(blockP)\n"
+      ir += "  %\(cp)seq_tile = zext i32 %\(cp)seq_tile32 to i64\n"
+
+      let dstStride = leadingDim * elemSize
+      let srcStride = leadingBlockDim * elemSize
+
+      let (tileW, tileH): (String, String)
+      if transposed {
+        ir += "  %\(cp)w_bytes32 = mul i32 %\(cp)seq_tile32, \(elemSize)\n"
+        ir += "  %\(cp)w_bytes = zext i32 %\(cp)w_bytes32 to i64\n"
+        tileW = "%\(cp)w_bytes"
+        tileH = "\(dTile)"
+      } else {
+        tileW = "\(dTile * elemSize)"
+        tileH = "%\(cp)seq_tile"
+      }
+
+      ir += "  %\(cp)tile_w = insertelement <2 x i64> zeroinitializer, i64 \(tileW), i32 0\n"
+      ir += "  %\(cp)tile = insertelement <2 x i64> %\(cp)tile_w, i64 \(tileH), i32 1\n"
+
+      ir += "  %\(cp)evp = getelementptr [2 x %event_t addrspace(3)*], [2 x %event_t addrspace(3)*]* %ev, i64 0, i64 0\n"
+      ir += """
+        %\(cp)ev = call %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p1i8.p3i8(
+          i64 1, i64 1,
+          i8 addrspace(1)* %\(cp)dst_p, i64 \(dstStride), i64 1, <2 x i64> %\(cp)tile,
+          i8 addrspace(3)* %\(cp)src_p, i64 \(srcStride), i64 1, <2 x i64> %\(cp)tile,
+          <2 x i64> zeroinitializer, i32 0
+        )
+        store %event_t addrspace(3)* %\(cp)ev, %event_t addrspace(3)** %\(cp)evp
+        call void @air.wait_simdgroup_events(i32 1, %event_t addrspace(3)** %\(cp)evp)
+
+      """
+
+      ir += "  br label %\(cp)skip\n\n"
+      ir += "\(cp)skip:\n"
+      ir += "  call void @air.wg.barrier(i32 2, i32 1)\n\n"
+
+      dOuter += UInt32(blockH)
+      iterIdx += 1
+    }
+
+    return ir
+  }
+
+  // MARK: - Backward Query Cleanup
+
+  func generateBackwardQueryCleanup(
+    prefix p: String,
+    dqCount: Int,
+    blockP: UInt16, blockH: UInt16,
+    D: UInt32, paddedD: UInt32, headEdge: UInt32,
+    headLoopFloor: UInt32,
+    parallelDim: UInt32,
+    regdQ: GEMMOperandPrecision, memdQ: GEMMOperandPrecision,
+    memD: GEMMOperandPrecision,
+    leadingDimdQ: UInt32, leadingBlockDimdQ: UInt32,
+    transposeddQ: Bool,
+    cacheddQ: Bool,
+    derivScale: Float
+  ) -> String {
+    let elemSizeD = UInt32(memD.size)
+    var ir = ""
+
+    ir += """
+
+    bq_cleanup:
+      ; === Backward Query cleanup: store dQ, store D ===
+
+    """
+
+    // Store dQ via cache store
+    ir += generateCacheStore(
+      operand: .dQ,
+      prefix: "\(p)q",
+      regCount: dqCount,
+      blockP: blockP, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim,
+      regPrec: regdQ, memPrec: memdQ,
+      leadingDim: leadingDimdQ, leadingBlockDim: leadingBlockDimdQ,
+      transposed: transposeddQ,
+      phiPrefix: "dq_phi"
+    )
+
+    // Store D scalar to device (scaled by derivScale for compatibility with
+    // the reference Metal source, which stores D * derivScale and uses
+    // dS = P * (dP * scale - D_stored). Our kernel uses D_sram raw internally
+    // with dS = P * (dP - D_sram) * scale, but the test expects scaled D.)
+    let dScaleHex = "0x\(String(Double(derivScale).bitPattern, radix: 16, uppercase: true))"
+    ir += "  ; Store D (scaled by derivScale)\n"
+    ir += "  %\(p)D_scaled = fmul fast float %D_sram, \(dScaleHex)\n"
+    ir += "  %\(p)D_in_bounds = icmp ult i32 %unsafe_par_off, \(parallelDim)\n"
+    ir += "  br i1 %\(p)D_in_bounds, label %\(p)store_D, label %\(p)skip_D\n\n"
+
+    ir += "\(p)store_D:\n"
+    ir += "  %\(p)D_off = zext i32 %clamped_par_off to i64\n"
+    ir += "  %\(p)D_byte = mul i64 %\(p)D_off, \(elemSizeD)\n"
+    ir += "  %\(p)D_ptr = getelementptr i8, i8 addrspace(1)* %D_buf, i64 %\(p)D_byte\n"
+    if memD == .FP32 {
+      ir += "  %\(p)D_typed = bitcast i8 addrspace(1)* %\(p)D_ptr to float addrspace(1)*\n"
+      ir += "  store float %\(p)D_scaled, float addrspace(1)* %\(p)D_typed\n"
+    } else {
+      let tD = irTypeName(memD)
+      ir += "  %\(p)D_trunc = fptrunc float %\(p)D_scaled to \(tD)\n"
+      ir += "  %\(p)D_typed = bitcast i8 addrspace(1)* %\(p)D_ptr to \(tD) addrspace(1)*\n"
+      ir += "  store \(tD) %\(p)D_trunc, \(tD) addrspace(1)* %\(p)D_typed\n"
+    }
+    ir += "  br label %\(p)skip_D\n\n"
+
+    ir += "\(p)skip_D:\n"
+    ir += "  br label %exit\n"
+
+    return ir
+  }
+
+  // MARK: - Backward Key-Value Cleanup
+
+  func generateBackwardKeyValueCleanup(
+    prefix p: String,
+    dkCount: Int, dvCount: Int,
+    blockP: UInt16, blockH: UInt16,
+    D: UInt32, paddedD: UInt32, headEdge: UInt32,
+    headLoopFloor: UInt32,
+    parallelDim: UInt32,
+    regdK: GEMMOperandPrecision, memdK: GEMMOperandPrecision,
+    regdV: GEMMOperandPrecision, memdV: GEMMOperandPrecision,
+    leadingDimdK: UInt32, leadingBlockDimdK: UInt32,
+    leadingDimdV: UInt32, leadingBlockDimdV: UInt32,
+    transposeddK: Bool, transposeddV: Bool,
+    cacheddK: Bool, cacheddV: Bool
+  ) -> String {
+    var ir = ""
+
+    ir += """
+
+    bkv_cleanup:
+      ; === Backward Key-Value cleanup: store dK, store dV ===
+
+    """
+
+    // Store dV via cache store
+    ir += generateCacheStore(
+      operand: .dV,
+      prefix: "\(p)v",
+      regCount: dvCount,
+      blockP: blockP, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim,
+      regPrec: regdV, memPrec: memdV,
+      leadingDim: leadingDimdV, leadingBlockDim: leadingBlockDimdV,
+      transposed: transposeddV,
+      phiPrefix: "dv_phi"
+    )
+
+    // Store dK via cache store
+    ir += generateCacheStore(
+      operand: .dK,
+      prefix: "\(p)k",
+      regCount: dkCount,
+      blockP: blockP, blockH: blockH,
+      D: D, paddedD: paddedD, headEdge: headEdge,
+      headLoopFloor: headLoopFloor,
+      parallelDim: parallelDim,
+      regPrec: regdK, memPrec: memdK,
+      leadingDim: leadingDimdK, leadingBlockDim: leadingBlockDimdK,
+      transposed: transposeddK,
+      phiPrefix: "dk_phi"
+    )
+
+    ir += "  br label %exit\n"
+
+    return ir
+  }
+}

--- a/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+Source.swift
+++ b/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+Source.swift
@@ -2,293 +2,294 @@
 //  AttentionKernel+Source.swift
 //  FlashAttention
 //
-//  Created by Philip Turner on 7/2/24.
+//  Generates a complete monolithic LLVM IR kernel for attention.
+//  Each (R, C, D, kernel_type, precision, transpose_state) config → unique IR.
+//  IR → MetalASM.assemble() → metallib → makeLibrary(data:) → pipeline.
+//
+//  All dimensions baked as literals (no function constants).
+//  Kernel runs straight through: setup → loop → cleanup (no state machine).
+//  Dynamic traversal loop with phi nodes for live SSA state.
 //
 
-// Top level specification of the code structure.
-
 extension AttentionKernel {
-  public func createSource() -> String {
-    func createLoop() -> String {
-      switch type {
-      case .forward:
-        return loopForward()
-      case .backwardQuery:
-        return loopBackwardQuery()
-      case .backwardKeyValue:
-        return loopBackwardKeyValue()
+
+  /// Problem-specific constants baked directly into IR as literals.
+  public struct MonolithicDescriptor {
+    public var R: UInt32 = 0          // row sequence length
+    public var C: UInt32 = 0          // column sequence length
+    /// Leading dimensions derived from transpose state + sequence lengths.
+    public var leadingDimensions: [AttentionOperand: UInt32] = [:]
+
+    public init() {}
+  }
+
+  /// Generate a complete LLVM IR module for a monolithic attention kernel.
+  ///
+  /// The returned string can be passed directly to `MetalASM.assemble(ir:)`
+  /// to produce a metallib loadable via `MTLDevice.makeLibrary(data:)`.
+  public func createSource(descriptor desc: MonolithicDescriptor) -> String {
+
+    let R = desc.R
+    let C = desc.C
+    let D = UInt32(headDimension)
+
+    // Compute derived dimensions
+    let blockP = blockDimensions.parallelization  // parallelization block
+    let blockT = blockDimensions.traversal         // traversal block
+    let blockH = blockDimensions.head              // head block
+
+    // For the forward kernel:
+    //   parallelization = R, traversal = C
+    //   Q, O are parallelization operands; K, V are traversal operands
+    let parallelDim: UInt32
+    let traversalDim: UInt32
+    switch type {
+    case .forward, .backwardQuery:
+      parallelDim = R
+      traversalDim = C
+    case .backwardKeyValue:
+      parallelDim = C
+      traversalDim = R
+    }
+
+    // Padded head dimension (round up to 8)
+    let paddedD = (D + 7) / 8 * 8
+
+    // Padded head edge
+    let headEdge: UInt32 = {
+      let blockDim = UInt32(blockH)
+      let remainder = D % blockDim
+      var output = (remainder == 0) ? blockDim : remainder
+      output = (output + 7) / 8 * 8
+      return output
+    }()
+
+    // Leading dimension helpers
+    func leadingDim(_ operand: AttentionOperand) -> UInt32 {
+      if let ld = desc.leadingDimensions[operand] {
+        return ld
+      }
+      // Default: if transposed, leading dim = sequence length; else = D
+      if transposed(operand) {
+        switch operand {
+        case .Q, .dQ: return R
+        case .K, .dK: return C
+        case .V, .dV: return C
+        case .O, .dO: return R
+        default: fatalError("Unrecognized operand.")
+        }
+      } else {
+        return D
       }
     }
-    
-    return """
-    
-    \(createMetalSimdgroupEvent())
-    \(createMetalSimdgroupMatrixStorage())
-    using namespace metal;
-    
-    \(createConstants())
-    
-    // Declare the function.
-    kernel void attention(
-      \(createBufferBindings())
-      threadgroup uchar *threadgroup_block [[threadgroup(0)]],
-      
-      uint gid [[threadgroup_position_in_grid]],
-      ushort sidx [[simdgroup_index_in_threadgroup]],
-      ushort lane_id [[thread_index_in_simdgroup]]
-    ) {
-      ushort2 morton_offset = morton_order(lane_id);
-      uint parallelization_group_offset = gid;
-      parallelization_group_offset *= \(blockDimensions.parallelization);
-      
-      // Return early if the entire SIMD is out of bounds.
-      if (\(parallelizationGroupOffset) >= \(parallelizationDimension)) {
-        return;
-      }
-      
-      \(createSetup())
-      \(createLoop())
-      \(createCleanup(type: type))
+
+    func leadingBlockDim(_ operand: AttentionOperand) -> UInt32 {
+      UInt32(leadingBlockDimension(operand))
     }
-    
-    """
-  }
-}
 
-// MARK: - Function Signature
+    // Memory precision helpers
+    func memPrec(_ operand: AttentionOperand) -> GEMMOperandPrecision {
+      memoryPrecisions[operand]!
+    }
+    func regPrec(_ operand: AttentionOperand) -> GEMMOperandPrecision {
+      registerPrecisions[operand]!
+    }
+    func memSize(_ operand: AttentionOperand) -> UInt32 {
+      UInt32(memPrec(operand).size)
+    }
 
-extension AttentionKernel {
-  func createConstants() -> String {
+    // S/P accumulator count = traversal_block / 8
+    let sSramCount = Int(blockT / 8)
+
+    // O accumulator count when cached = paddedD / 8
+    // O accumulator count when not cached = blockH / 8
+    let oCachedCount = Int(paddedD / 8)
+
+    // Head loop bounds
+    let headLoopEnd = paddedD
+    let headLoopFloor = headLoopEnd - headLoopEnd % UInt32(blockH)
+
+    // TG memory size (in floats, for the global buffer)
+    let tgFloats = max(8192, (Int(threadgroupMemoryAllocation) + 128 + 3) / 4)
+
+    // Scale factor: log2(e) / sqrt(D)
+    let logBase2E: Float = 1.442695041
+    let scaleFactor = logBase2E / Float(headDimension).squareRoot()
+
+    // Determine which multiply-accumulate intrinsics we need
+    var maDeclarations = Set<String>()
+
+    // For S = Q * K^T (outer product)
+    let regS = regPrec(.S)
+    let regQ = regPrec(.Q)
+    let regK = regPrec(.K)
+    maDeclarations.insert(irMultiplyAccumulateDeclaration(A: regQ, B: regK, C: regS))
+
+    // For O += P * V (accumulate)
+    let regO = regPrec(.O)
+    let regP = regPrec(.P)
+    let regV = regPrec(.V)
+    maDeclarations.insert(irMultiplyAccumulateDeclaration(A: regP, B: regV, C: regO))
+
+    if type == .backwardQuery {
+      // dP = dO * V^T
+      let regdP = regPrec(.dP)
+      let regdO = regPrec(.dO)
+      maDeclarations.insert(irMultiplyAccumulateDeclaration(A: regdO, B: regV, C: regdP))
+      // dQ += dS * K
+      let regdS = regPrec(.dS)
+      let regdQ = regPrec(.dQ)
+      maDeclarations.insert(irMultiplyAccumulateDeclaration(A: regdS, B: regK, C: regdQ))
+    }
+
+    if type == .backwardKeyValue {
+      // S^T = K * Q^T
+      maDeclarations.insert(irMultiplyAccumulateDeclaration(A: regK, B: regQ, C: regS))
+      // dV += P^T * dO
+      let regdO = regPrec(.dO)
+      let regdV = regPrec(.dV)
+      maDeclarations.insert(irMultiplyAccumulateDeclaration(A: regP, B: regdO, C: regdV))
+      // dP^T = V * dO^T
+      let regdP = regPrec(.dP)
+      maDeclarations.insert(irMultiplyAccumulateDeclaration(A: regV, B: regdO, C: regdP))
+      // dK += dS^T * Q
+      let regdS = regPrec(.dS)
+      let regdK = regPrec(.dK)
+      maDeclarations.insert(irMultiplyAccumulateDeclaration(A: regdS, B: regQ, C: regdK))
+    }
+
+    // MARK: - IR Generation
+
+    var ir = ""
+
+    // Module header
+    ir += irModuleHeader(tgBufferFloats: tgFloats) + "\n"
+    ir += irIntrinsicDeclarations() + "\n"
+    ir += irAttentionIntrinsicDeclarations() + "\n"
+
+    // Multiply-accumulate intrinsic declarations
+    for decl in maDeclarations.sorted() {
+      ir += "  \(decl)\n"
+    }
+
+    // Kernel function signature: 10 device buffers + 1 TG buffer + gid + sidx + lane_id
+    ir += """
+
+    define void @attention(
+        i8 addrspace(1)* noundef "air-buffer-no-alias" %Q,
+        i8 addrspace(1)* noundef "air-buffer-no-alias" %K,
+        i8 addrspace(1)* noundef "air-buffer-no-alias" %V,
+        i8 addrspace(1)* noundef "air-buffer-no-alias" %O,
+        i8 addrspace(1)* noundef "air-buffer-no-alias" %L_buf,
+        i8 addrspace(1)* noundef "air-buffer-no-alias" %D_buf,
+        i8 addrspace(1)* noundef "air-buffer-no-alias" %dO,
+        i8 addrspace(1)* noundef "air-buffer-no-alias" %dV,
+        i8 addrspace(1)* noundef "air-buffer-no-alias" %dK,
+        i8 addrspace(1)* noundef "air-buffer-no-alias" %dQ,
+        i8 addrspace(3)* noundef %tg_base,
+        <3 x i32> noundef %gid,
+        i16 noundef %sidx_i16,
+        i16 noundef %lane_id_i16
+    ) local_unnamed_addr #0 {
+    entry:
+      %sidx = zext i16 %sidx_i16 to i32
+      %lane_id = zext i16 %lane_id_i16 to i32
+      %gid_x = extractelement <3 x i32> %gid, i64 0
+
+      ; Event alloca for async copy
+      %ev = alloca [2 x %event_t addrspace(3)*], align 8
+      %ev_i8 = bitcast [2 x %event_t addrspace(3)*]* %ev to i8*
+      call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %ev_i8) #4
+
+      ; === Morton order computation ===
+      %q = lshr i32 %lane_id, 2
+      %m_floor = and i32 %q, 16380
+      %h = lshr i32 %lane_id, 1
+      %m_in_quad = and i32 %h, 3
+      %morton_y = or i32 %m_floor, %m_in_quad
+      %n_floor = and i32 %h, 4
+      %n_in_quad_s = shl i32 %lane_id, 1
+      %n_in_quad = and i32 %n_in_quad_s, 2
+      %morton_x = or i32 %n_floor, %n_in_quad
+
+      ; parallelization_group_offset = gid.x * blockP
+      %par_group_off = mul i32 %gid_x, \(blockP)
+
+      ; Early return if entire group is out of bounds
+      %early_oob = icmp uge i32 %par_group_off, \(parallelDim)
+      br i1 %early_oob, label %exit, label %valid_group
+
+    valid_group:
+      ; Gate async copies to simdgroup 0
+      %is_sidx0 = icmp eq i32 %sidx, 0
+
+      ; Compute thread offsets within group
+      ; oig_y = sidx * 8 + morton_y (parallelization offset within group)
+      %oig_y_base = mul i32 %sidx, 8
+      %oig_y = add i32 %oig_y_base, %morton_y
+
+      ; unsafe_par_thread_off = par_group_off + oig_y
+      %unsafe_par_off = add i32 %par_group_off, %oig_y
+      ; clamped_par_off = min(unsafe_par_off, parallelDim - 1)
+      %par_dim_m1 = sub i32 \(parallelDim), 1
+      %par_cmp = icmp ult i32 %unsafe_par_off, \(parallelDim)
+      %clamped_par_off = select i1 %par_cmp, i32 %unsafe_par_off, i32 %par_dim_m1
+
     """
-    
-    // R = row dimension (output sequence)
-    // C = column dimension (input sequence)
-    constant uint R [[function_constant(0)]];
-    constant uint C [[function_constant(1)]];
-    
-    """
-  }
-  
-  func createBufferBindings() -> String {
-    // What operands does the kernel use?
-    var operands: [AttentionOperand] = []
+
+    // Dispatch to kernel type
     switch type {
     case .forward:
-      // To simplify the implementation, we always compute log-sum-exp in the
-      // forward pass. Even when it will never be used (model inference).
-      // If this is an issue, clients can change the code to selectively
-      // omit the 'L' operand.
-      operands += [.Q, .K, .V, .O]
-      operands += [.L]
+      ir += generateForwardKernel(
+        desc: desc, R: R, C: C, D: D,
+        blockP: blockP, blockT: blockT, blockH: blockH,
+        parallelDim: parallelDim, traversalDim: traversalDim,
+        paddedD: paddedD, headEdge: headEdge,
+        headLoopFloor: headLoopFloor,
+        oCachedCount: oCachedCount, sSramCount: sSramCount,
+        scaleFactor: scaleFactor, tgFloats: tgFloats,
+        leadingDim: leadingDim, leadingBlockDim: leadingBlockDim,
+        memPrec: memPrec, regPrec: regPrec, memSize: memSize
+      )
     case .backwardQuery:
-      operands += [.Q, .K, .V, .O]
-      operands += [.dO, .dQ]
-      operands += [.L, .D]
+      ir += generateBackwardQueryKernel(
+        desc: desc, R: R, C: C, D: D,
+        blockP: blockP, blockT: blockT, blockH: blockH,
+        parallelDim: parallelDim, traversalDim: traversalDim,
+        paddedD: paddedD, headEdge: headEdge,
+        headLoopFloor: headLoopFloor,
+        sSramCount: sSramCount,
+        scaleFactor: scaleFactor, tgFloats: tgFloats,
+        leadingDim: leadingDim, leadingBlockDim: leadingBlockDim,
+        memPrec: memPrec, regPrec: regPrec, memSize: memSize
+      )
     case .backwardKeyValue:
-      operands += [.Q, .K, .V]
-      operands += [.dO, .dV, .dK]
-      operands += [.L, .D]
+      ir += generateBackwardKeyValueKernel(
+        desc: desc, R: R, C: C, D: D,
+        blockP: blockP, blockT: blockT, blockH: blockH,
+        parallelDim: parallelDim, traversalDim: traversalDim,
+        paddedD: paddedD, headEdge: headEdge,
+        headLoopFloor: headLoopFloor,
+        sSramCount: sSramCount,
+        scaleFactor: scaleFactor, tgFloats: tgFloats,
+        leadingDim: leadingDim, leadingBlockDim: leadingBlockDim,
+        memPrec: memPrec, regPrec: regPrec, memSize: memSize
+      )
     }
-    operands.sort {
-      $0.bufferBinding! < $1.bufferBinding!
-    }
-    
-    var output: String = ""
-    for operand in operands {
-      var line = "device \(memoryName(operand))* \(operand) "
-      line += "[[buffer(\(operand.bufferBinding!))]],"
-      output += "  " + line + "\n"
-    }
-    return output
-  }
-}
 
-// MARK: - Outer Loop
+    // Exit block
+    ir += """
 
-// Forward
-//   for c in 0..<C {
-//     load K[c]
-//     S = Q * K^T
-//     (m, l, P) = softmax(m, l, S * scaleFactor)
-//
-//     O *= correction
-//     load V[c]
-//     O += P * V
-//   }
-//   O /= l
-//
-//   L = m + logBaseE(l)
-//
-// Backward Query
-//   D = dO * O
-//
-//   for c in 0..<C {
-//     load K[c]
-//     S = Q * K^T
-//     P = exp(S - L)
-//
-//     load V[c]
-//     dP = dO * V^T
-//     dS = P * (dP - D) * scaleFactor
-//
-//     load K[c]
-//     dQ += dS * K
-//   }
-//
-// Backward Key-Value
-//   for r in 0..<R {
-//     load Q[r]
-//     load L[r]
-//     S^T = K * Q^T
-//     P^T = exp(S^T - L)
-//
-//     load dO[r]
-//     dV += P^T * dO
-//
-//     load dO[r]
-//     load D[r]
-//     dP^T = V * dO^T
-//     dS^T = P^T * (dP^T - D) * scaleFactor
-//
-//     load Q[r]
-//     dK += dS^T * Q
-//   }
+    exit:
+      call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %ev_i8) #4
+      ret void
+    }
 
-extension AttentionKernel {
-  func loopForward() -> String {
-    var outerProductDesc = AttentionOuterProductDescriptor()
-    outerProductDesc.A = .Q
-    outerProductDesc.B = .K
-    outerProductDesc.C = .S
-    let QKT = outerProduct(descriptor: outerProductDesc)
-    
-    var accumulateDesc = AttentionAccumulateDescriptor()
-    accumulateDesc.A = .P
-    accumulateDesc.B = .V
-    accumulateDesc.C = .O
-    accumulateDesc.everyIterationScale = "correction"
-    accumulateDesc.lastIterationScale = "fast::divide(1, l)"
-    let PV = accumulate(descriptor: accumulateDesc)
-    
-    return """
-    
-    // Outer loop over the traversal dimension.
-    for (uint c = 0; c < C; c += \(blockDimensions.traversal)) {
-      // S = Q * K^T
-      \(QKT)
-      \(maskAttentionMatrixEdge())
-      
-      // m = reduce(m)
-      \(onlineReduceMaximum())
-      
-      // correction = exp(m_old) / exp(m_new)
-      \(onlineCorrectO())
-      
-      // P = softmax(S * scaleFactor)
-      \(softmax(derivative: false))
-      
-      // l = reduce(l)
-      \(onlineReduceSum())
-      
-      // O *= correction
-      // O += P * V
-      // O /= l
-      \(PV)
-    }
-    
     """
-  }
-  
-  func loopBackwardQuery() -> String {
-    var outerProductDesc = AttentionOuterProductDescriptor()
-    outerProductDesc.A = .Q
-    outerProductDesc.B = .K
-    outerProductDesc.C = .S
-    let QKT = outerProduct(descriptor: outerProductDesc)
-    
-    outerProductDesc = AttentionOuterProductDescriptor()
-    outerProductDesc.A = .dO
-    outerProductDesc.B = .V
-    outerProductDesc.C = .dP
-    let dOVT = outerProduct(descriptor: outerProductDesc)
-    
-    var accumulateDesc = AttentionAccumulateDescriptor()
-    accumulateDesc.A = .dS
-    accumulateDesc.B = .K
-    accumulateDesc.C = .dQ
-    let dSK = accumulate(descriptor: accumulateDesc)
-    
-    return """
-    
-    // Outer loop over the traversal dimension.
-    for (uint c = 0; c < C; c += \(blockDimensions.traversal)) {
-      // S = Q * K^T
-      \(QKT)
-      
-      // P = softmax(S * scaleFactor)
-      \(softmax(derivative: false))
-      
-      // dP = dO * V^T
-      \(dOVT)
-      
-      // dS = P * (dP - D) * scaleFactor
-      \(softmax(derivative: true))
-      
-      // dQ += dS * K
-      \(dSK)
-    }
-    
-    """
-  }
-  
-  func loopBackwardKeyValue() -> String {
-    var outerProductDesc = AttentionOuterProductDescriptor()
-    outerProductDesc.A = .K
-    outerProductDesc.B = .Q
-    outerProductDesc.C = .S // S^T
-    let KQT = outerProduct(descriptor: outerProductDesc)
-    
-    var accumulateDesc = AttentionAccumulateDescriptor()
-    accumulateDesc.A = .P // P^T
-    accumulateDesc.B = .dO
-    accumulateDesc.C = .dV
-    let PTdO = accumulate(descriptor: accumulateDesc)
-    
-    outerProductDesc = AttentionOuterProductDescriptor()
-    outerProductDesc.A = .V
-    outerProductDesc.B = .dO
-    outerProductDesc.C = .dP // dP^T
-    let VdOT = outerProduct(descriptor: outerProductDesc)
-    
-    accumulateDesc = AttentionAccumulateDescriptor()
-    accumulateDesc.A = .dS // dS^T
-    accumulateDesc.B = .Q
-    accumulateDesc.C = .dK
-    let dSTQ = accumulate(descriptor: accumulateDesc)
-    
-    return """
-    
-    // Outer loop over the traversal dimension.
-    for (uint r = 0; r < R; r += \(blockDimensions.traversal)) {
-      // S^T = K * Q^T
-      \(KQT)
-      
-      // P^T = exp(S^T - L)
-      \(softmax(derivative: false))
-      
-      // dV += P^T * dO
-      \(PTdO)
-      
-      // dP^T = V * dO^T
-      \(VdOT)
-      
-      // dS^T = P^T * (dP^T - D) * scaleFactor
-      \(softmax(derivative: true))
-      
-      // dK += dS^T * Q
-      \(dSTQ)
-    }
-    
-    """
+
+    // Metadata
+    ir += irAttentionKernelMetadata() + "\n"
+
+    return ir
   }
 }

--- a/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel.swift
+++ b/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel.swift
@@ -23,7 +23,11 @@ public struct AttentionKernel {
     parallelization: UInt16, traversal: UInt16, head: UInt16)
   var headDimension: UInt16
   public var threadgroupMemoryAllocation: UInt16
-  
+
+  /// For forward double-buffering: size of one TG slot (K or V).
+  /// The total TG allocation is 2 * forwardTGSlotSize for forward kernels.
+  public var forwardTGSlotSize: UInt16
+
   public init(descriptor: AttentionKernelDescriptor) {
     guard let blockDimensions = descriptor.blockDimensions,
           let headDimension = descriptor.headDimension,
@@ -43,7 +47,26 @@ public struct AttentionKernel {
     
     self.blockDimensions = blockDimensions
     self.headDimension = headDimension
-    
+
+    // Compute forward TG slot size for double-buffering
+    if type == .forward {
+      var slotSize: UInt16 = 0
+      var kBytes: UInt16 = 1
+      kBytes *= blockDimensions.traversal
+      kBytes *= blockDimensions.head
+      kBytes *= UInt16(descriptor.memoryPrecisions[.K]!.size)
+      slotSize = max(slotSize, kBytes)
+
+      var vBytes: UInt16 = 1
+      vBytes *= blockDimensions.traversal
+      vBytes *= blockDimensions.head
+      vBytes *= UInt16(descriptor.memoryPrecisions[.V]!.size)
+      slotSize = max(slotSize, vBytes)
+      forwardTGSlotSize = slotSize
+    } else {
+      forwardTGSlotSize = .zero
+    }
+
     // Pick the threadgroup memory allocation size.
     threadgroupMemoryAllocation = .zero
     threadgroupMemoryAllocation = createThreadgroupMemoryAllocation()
@@ -302,14 +325,14 @@ extension AttentionKernel {
     // Allocate memory for the GEMM operands.
     switch type {
     case .forward:
-      // S = Q * K^T
+      // Double-buffer: K uses TG slot A, V uses TG slot B.
+      // Both slots are forwardTGSlotSize bytes. Total = 2 * slotSize.
+      output = 2 * forwardTGSlotSize
+
+      // Also ensure enough for cleanup store (Q/O parallelization operands)
       allocateParallelization(.Q)
-      allocateTraversal(.K)
-      
-      // O += P * V
       allocateParallelization(.O)
-      allocateTraversal(.V)
-      
+
     case .backwardQuery:
       // S = Q * K^T
       allocateParallelization(.Q)

--- a/Sources/FlashAttention/GEMM/GEMMKernel/GEMMKernel+Source.swift
+++ b/Sources/FlashAttention/GEMM/GEMMKernel/GEMMKernel+Source.swift
@@ -2,158 +2,957 @@
 //  GEMMKernel+Source.swift
 //  FlashAttention
 //
-//  Created by Philip Turner on 8/3/24.
+//  Generates a complete monolithic LLVM IR kernel for GEMM.
+//  All K iterations are unrolled inline: async copy → barrier → multiply.
+//  C accumulators stay in registers throughout — no save/restore to TG.
+//  No dispatch loop, no command protocol, no visible function overhead.
+//
+//  Assembled in-process via MetalASM: parse → bitcode → metallib.
 //
 
 extension GEMMKernel {
-  public func createSource() -> String {
-    return """
 
-\(createMetalSimdgroupEvent())
-\(createMetalSimdgroupMatrixStorage())
-using namespace metal;
+  /// All the problem-specific constants that would have been function constants
+  /// in the reverse-linking path. Now baked directly into the IR as literals.
+  public struct MonolithicDescriptor {
+    public var M: UInt32 = 0
+    public var N: UInt32 = 0
+    public var K: UInt32 = 0
+    public var leadingDimensionA: UInt32 = 0
+    public var leadingDimensionB: UInt32 = 0
+    public var leadingDimensionC: UInt32 = 0
+    public var loadPreviousC: Bool = false
 
-\(createConstants())
-\(createUtilities())
-
-// Metal function arguments.
-//
-// A: the left-hand side matrix
-// - dimensions: M x K
-//               K x M (transposed)
-// - memory precision: memA
-// - register precision: regA
-//
-// B: the right-hand side matrix
-// - dimensions: K x N
-//               N x K (transposed)
-// - memory precision: memB
-// - register precision: regB
-//
-// C: the output matrix, alternatively the dot product accumulator
-// - dimensions: M x N
-// - memory precision: memC
-// - register precision: regC
-//
-// threadgroup_block: the chunk of threadgroup memory allocated at runtime
-// - ideally 10 KB or less
-// - precision: void/8-bit integer to make the pointer arithmetic more legible
-
-kernel void gemm(device \(memoryName("A")) *A [[buffer(0)]],
-                 device \(memoryName("B")) *B [[buffer(1)]],
-                 device \(memoryName("C")) *C [[buffer(2)]],
-                 threadgroup uchar *threadgroup_block [[threadgroup(0)]],
-                 
-                 uint3 gid [[threadgroup_position_in_grid]],
-                 ushort sidx [[simdgroup_index_in_threadgroup]],
-                 ushort lane_id [[thread_index_in_simdgroup]])
-{
-  ushort2 sid(sidx % \(splits.N), sidx / \(splits.N));
-  ushort2 morton_offset = morton_order(lane_id);
-  
-  // Return early if the SIMD is out of bounds.
-  //
-  // There could be some threadgroups where the matrix edge cuts straight
-  // through the middle of the block. SIMDs on the right or bottom of the
-  // dividing line must be stopped from causing out-of-bounds accesses. This is
-  // the reason for the early exit.
-  uint M_offset = gid.y * M_group;
-  uint N_offset = gid.x * N_group;
-  if (M_offset + sid.y * \(registerM) >= M ||
-      N_offset + sid.x * \(registerN) >= N) {
-    return;
-  }
-  ushort2 offset_in_group(sid.x * \(registerN) + morton_offset.x,
-                          sid.y * \(registerM) + morton_offset.y);
-  
-  // Shift the matrix block within bounds, if possible.
-  if ((M_shift != 0) && (gid.y * M_group >= M_edge)) {
-    M_offset -= M_shift;
-  }
-  if ((N_shift != 0) && (gid.x * N_group >= N_edge)) {
-    N_offset -= N_shift;
+    public init() {}
   }
 
-  \(createInitializeC())
-  \(createMultiplyIterations())
-  \(createStoreC())
-}
+  /// Generate a complete LLVM IR module for a monolithic GEMM kernel.
+  ///
+  /// The returned string can be passed directly to `MetalASM.assemble(ir:)`
+  /// to produce a metallib loadable via `MTLDevice.makeLibrary(data:)`.
+  public func createSource(descriptor desc: MonolithicDescriptor) -> String {
+    let M = desc.M
+    let N = desc.N
+    let K = desc.K
+    let ldA = desc.leadingDimensionA
+    let ldB = desc.leadingDimensionB
+    let ldC = desc.leadingDimensionC
 
-"""
-  }
-}
+    // Derived constants (same logic as createConstants() in Source.swift)
+    let M_group = blockDimensions.M
+    let N_group = blockDimensions.N
+    let K_group = blockDimensions.K
+    let regM = registerM
+    let regN = registerN
 
-extension GEMMKernel {
-  func createConstants() -> String {
+    let M_edge = M - (M % UInt32(M_group))
+    let N_edge = N - (N % UInt32(N_group))
+    let M_remainder = (M % UInt32(regM) == 0) ? regM : UInt16(M % UInt32(regM))
+    let N_remainder = (N % UInt32(regN) == 0) ? regN : UInt16(N % UInt32(regN))
+
+    let M_shift: UInt16 = (M < UInt32(M_group)) ? 0 : regM - M_remainder
+    let N_shift: UInt16 = (N < UInt32(N_group)) ? 0 : regN - N_remainder
+
+    let asyncIterationsStart: UInt32 = preferAsyncLoad ? 0 : (K - (K % UInt32(K_group)))
+    let numAsyncIterations = (K > asyncIterationsStart)
+      ? (K - asyncIterationsStart + UInt32(K_group) - 1) / UInt32(K_group)
+      : 0
+
+    let cSramCount = Int(regM / 8) * Int(regN / 8)
+    let blockBytesA = Int(blockBytes("A"))
+
+    // Precision types
+    let regA = registerPrecisions.A
+    let regB = registerPrecisions.B
+    let regC = registerPrecisions.C
+    let _ = memoryPrecisions.A  // used in sub-generators
+    let _ = memoryPrecisions.B
+    let _ = memoryPrecisions.C
+
+    // Determine which multiply-accumulate intrinsic variants we need.
+    var maDeclarations = Set<String>()
+    maDeclarations.insert(irMultiplyAccumulateDeclaration(A: regA, B: regB, C: regC))
+
+    // TG buffer: just enough for A block + B block (no C save area needed!)
+    let tgFloats = max(8192, (Int(threadgroupMemoryAllocation) + 128 + 3) / 4)
+
+    // MARK: - IR Generation
+
+    var ir = ""
+
+    // Module header
+    ir += irModuleHeader(tgBufferFloats: tgFloats) + "\n"
+    ir += irIntrinsicDeclarations() + "\n"
+
+    // Multiply-accumulate intrinsic declarations
+    for decl in maDeclarations {
+      ir += "  \(decl)\n"
+    }
+
+    // Kernel function signature: 3 device buffers + 1 TG buffer + gid + sidx + lane_id
+    ir += """
+
+    define void @gemm(
+        i8 addrspace(1)* noundef "air-buffer-no-alias" %A,
+        i8 addrspace(1)* noundef "air-buffer-no-alias" %B,
+        i8 addrspace(1)* noundef "air-buffer-no-alias" %C,
+        i8 addrspace(3)* noundef %tg_base,
+        <3 x i32> noundef %gid,
+        i16 noundef %sidx_i16,
+        i16 noundef %lane_id_i16
+    ) local_unnamed_addr #0 {
+    entry:
+      %sidx = zext i16 %sidx_i16 to i32
+      %lane_id = zext i16 %lane_id_i16 to i32
+      %gid_x = extractelement <3 x i32> %gid, i64 0
+      %gid_y = extractelement <3 x i32> %gid, i64 1
+
+      ; Event alloca for async copy
+      %ev = alloca [2 x %event_t addrspace(3)*], align 8
+      %ev_i8 = bitcast [2 x %event_t addrspace(3)*]* %ev to i8*
+      call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %ev_i8) #4
+
+      ; === Morton order computation ===
+      %q = lshr i32 %lane_id, 2
+      %m_floor = and i32 %q, 16380
+      %h = lshr i32 %lane_id, 1
+      %m_in_quad = and i32 %h, 3
+      %morton_y = or i32 %m_floor, %m_in_quad
+      %n_floor = and i32 %h, 4
+      %n_in_quad_s = shl i32 %lane_id, 1
+      %n_in_quad = and i32 %n_in_quad_s, 2
+      %morton_x = or i32 %n_floor, %n_in_quad
+
+      ; sid.x = sidx % splits.N, sid.y = sidx / splits.N
+      %sid_x = urem i32 %sidx, \(splits.N)
+      %sid_y = udiv i32 %sidx, \(splits.N)
+
+      ; offset_in_group = (sid.x * regN + morton_x, sid.y * regM + morton_y)
+      %oig_x_base = mul i32 %sid_x, \(regN)
+      %oig_x = add i32 %oig_x_base, %morton_x
+      %oig_y_base = mul i32 %sid_y, \(regM)
+      %oig_y = add i32 %oig_y_base, %morton_y
+
+      ; M_offset and N_offset
+      %M_offset_base = mul i32 %gid_y, \(M_group)
+      %N_offset_base = mul i32 %gid_x, \(N_group)
+
+      ; Gate async copies to simdgroup 0
+      %is_sidx0 = icmp eq i32 %sidx, 0
+
     """
-    
-// Dimensions of each matrix.
-// - Limitations to matrix size:
-//   - 2^32 in each dimension (M/N/K).
-//   - Extending to 2^64 may require changing 'uint' to 'ulong'. There is a
-//     good chance this will significantly degrade performance, and require
-//     changing the data type of several variables that process addresses. The
-//     client is responsible for ensuring correctness and performance with
-//     matrices spanning several billion elements in one direction.
-//   - The matrix dimensions must be known at compile time, via function
-//     constants. Dynamic matrix shapes are beyond the scope of this reference
-//     implementation. Dynamic shapes cause a non-negligible regression to
-//     shader execution speed. However, they could minimize a compilation
-//     latency bottleneck in some use cases.
-// - Limitations to batch size:
-//   - Dictated by how the client modifies the code to implement batching.
-//   - Dynamic batch shapes would likely not harm performance much. For example,
-//     someone could enter an array of pointers/memory offsets to different
-//     matrices in the batch. Each slice of a 3D thread grid could read a
-//     different pointer from memory, and use that pointer as the A/B/C matrix.
-//     Another approach is to restrict the input format, so all matrices are
-//     stored contiguously in memory. Then, the memory offset could be computed
-//     analytically from matrix size and the Z dimension in a 3D thread grid.
-//
-// Another note:
-// - The rows of the matrix must be contiguous in memory. Supporting strides
-//   that differ from the actual matrix dimensions should not be difficult, but
-//   it is out of scope for this reference kernel.
-constant uint M [[function_constant(0)]];
-constant uint N [[function_constant(1)]];
-constant uint K [[function_constant(2)]];
 
-// Specify the leading dimensions at PSO creation time.
-constant uint A_leading_dimension [[function_constant(5)]];
-constant uint B_leading_dimension [[function_constant(6)]];
-constant uint C_leading_dimension [[function_constant(7)]];
+    // Edge shifting
+    if M_shift != 0 {
+      ir += """
+        ; M edge shift
+        %m_edge_cmp = icmp uge i32 %M_offset_base, \(M_edge)
+        %m_shift_val = select i1 %m_edge_cmp, i32 \(M_shift), i32 0
+        %M_offset = sub i32 %M_offset_base, %m_shift_val
 
-// Whether to load the previous value of C, and add it to the accumulator.
-constant bool load_previous_C [[function_constant(10)]];
+      """
+    } else {
+      ir += "  %M_offset = add i32 %M_offset_base, 0\n"
+    }
 
-// Whether each matrix is transposed.
-constant bool A_trans = \(transposeState.A);
-constant bool B_trans = \(transposeState.B);
+    if N_shift != 0 {
+      ir += """
+        ; N edge shift
+        %n_edge_cmp = icmp uge i32 %N_offset_base, \(N_edge)
+        %n_shift_val = select i1 %n_edge_cmp, i32 \(N_shift), i32 0
+        %N_offset = sub i32 %N_offset_base, %n_shift_val
 
-// Define the memory layout of the matrix block.
-constant ushort M_group = \(blockDimensions.M);
-constant ushort N_group = \(blockDimensions.N);
-constant ushort K_group = \(blockDimensions.K);
+      """
+    } else {
+      ir += "  %N_offset = add i32 %N_offset_base, 0\n"
+    }
 
-// Thresholds that mark the matrix edge.
-constant uint M_edge = M - (M % M_group);
-constant uint N_edge = N - (N % N_group);
+    // Out-of-bounds check
+    ir += """
+      ; out_of_bounds = (M_offset + sid.y * regM >= M) || (N_offset + sid.x * regN >= N)
+      %oob_m_off = add i32 %M_offset, %oig_y_base
+      %oob_m = icmp uge i32 %oob_m_off, \(M)
+      %oob_n_off = add i32 %N_offset, %oig_x_base
+      %oob_n = icmp uge i32 %oob_n_off, \(N)
+      %out_of_bounds = or i1 %oob_m, %oob_n
 
-// Find the number of elements in the final block. If the matrix
-// dimensions are perfectly divisibly by block dimensions, we don't want
-// this value to be zero. The final block is a full block.
-constant ushort M_remainder = (M % \(registerM) == 0)
-  ? \(registerM) : M % \(registerM);
-constant ushort N_remainder = (N % \(registerN) == 0)
-  ? \(registerN) : N % \(registerN);
-constant ushort K_remainder = (K % K_group == 0)
-  ? K_group : K % K_group;
-constant ushort K_remainder_padded = (K_remainder + 7) / 8 * 8;
+    """
 
-// Shift the final block, so it doesn't access out-of-bounds memory.
-constant ushort M_shift = (M < M_group) ? 0 : \(registerM) - M_remainder;
-constant ushort N_shift = (N < N_group) ? 0 : \(registerN) - N_remainder;
+    // Initialize C accumulators to zero
+    for i in 0..<cSramCount {
+      ir += "  \(irZeroVec64(result: "%c_init_\(i)", precision: regC))\n"
+    }
 
-"""
+    // === loadPreviousC: async copy C from device → TG, load into accumulators ===
+    if desc.loadPreviousC {
+      ir += generateInlineLoadC(
+        desc: desc, ldC: ldC,
+        M_group: M_group, N_group: N_group,
+        cSramCount: cSramCount
+      )
+      // After this block, %c_start_N hold the loaded values (or zero if OOB)
+    } else {
+      // C starts as zero
+      for i in 0..<cSramCount {
+        ir += "  %c_start_\(i) = bitcast \(irVecType(regC)) %c_init_\(i) to \(irVecType(regC))\n"
+      }
+    }
+
+    // === Main K loop: fully unrolled, C stays in registers ===
+    //
+    // Structure for each async iteration i (0..numAsyncIterations-1):
+    //   1. Inline async copy (A+B) for k = asyncIterationsStart + i * K_group
+    //   2. Barrier (wait for data)
+    //   3. Multiply-accumulate from TG data (K_group steps of 8)
+    //
+    // Between iterations, C accumulators are SSA-chained:
+    //   %c_iter0_N → %c_iter1_N → ... → %c_final_N
+
+    // Track current C accumulator names
+    var cNames = (0..<cSramCount).map { "%c_start_\($0)" }
+
+    for iter in 0..<Int(numAsyncIterations) {
+      let kStart = asyncIterationsStart + UInt32(iter) * UInt32(K_group)
+      let kRemaining = K - kStart
+      let kTile = min(UInt32(K_group), kRemaining)
+      let kSteps = Int((kTile + 7) / 8)
+      let p = "it\(iter)_"
+
+      // 1. Inline async copy for A and B (gated to sidx == 0)
+      ir += "  br i1 %is_sidx0, label %\(p)do_copy, label %\(p)skip_copy\n\n"
+      ir += "\(p)do_copy:\n"
+      ir += generateInlineDualCopy(
+        prefix: p,
+        kStart: kStart, kTile: kTile,
+        ldA: ldA, ldB: ldB,
+        M_group: M_group, N_group: N_group, K_group: K_group,
+        blockBytesA: blockBytesA,
+        M: M, N: N
+      )
+      ir += "  br label %\(p)after_copy\n\n"
+      ir += "\(p)skip_copy:\n"
+      ir += "  br label %\(p)after_copy\n\n"
+      ir += "\(p)after_copy:\n"
+
+      // 2. Barrier after copy (all threads must wait)
+      ir += "  call void @air.wg.barrier(i32 2, i32 1)\n\n"
+
+      // 3. Multiply-accumulate from TG
+      let newNames = generateInlineTGMultiply(
+        prefix: p,
+        kSteps: kSteps,
+        regM: regM, regN: regN,
+        blockBytesA: blockBytesA,
+        cSramCount: cSramCount,
+        cInputNames: cNames
+      )
+      ir += newNames.ir
+
+      // If not last iteration, barrier before next copy overwrites TG
+      if iter < Int(numAsyncIterations) - 1 {
+        ir += "  call void @air.wg.barrier(i32 2, i32 1)\n\n"
+      }
+
+      cNames = newNames.outputNames
+    }
+
+    // === Store C to TG and async copy to device ===
+    // After all multiply iterations, cNames holds the final accumulators.
+    // We use %c_final_N aliases for the store logic.
+    for i in 0..<cSramCount {
+      ir += "  %c_final_\(i) = bitcast \(irVecType(regC)) \(cNames[i]) to \(irVecType(regC))\n"
+    }
+
+    // CRITICAL: Barrier before C store to ensure all simdgroups are done reading
+    // A/B from TG (since C store overwrites the A/B area in TG).
+    ir += "  call void @air.wg.barrier(i32 2, i32 1)\n\n"
+
+    // Fast path: direct register → device store for non-edge threadgroups.
+    // Static condition: M >= M_group && N >= N_group (checked at codegen time).
+    // Runtime condition: not an edge threadgroup (M_offset_base < M_edge && N_offset_base < N_edge).
+    let canDirectStore = !preferAsyncStore
+      && M >= UInt32(M_group)
+      && N >= UInt32(N_group)
+
+    if canDirectStore {
+      // Runtime edge check
+      ir += "  ; Fast path: direct device store for non-edge threadgroups\n"
+      ir += "  %fast_not_edge_m = icmp ult i32 %M_offset_base, \(M_edge)\n"
+      ir += "  %fast_not_edge_n = icmp ult i32 %N_offset_base, \(N_edge)\n"
+      ir += "  %fast_use_direct = and i1 %fast_not_edge_m, %fast_not_edge_n\n"
+      ir += "  br i1 %fast_use_direct, label %c_direct_store, label %c_slow_store\n\n"
+
+      // Fast path: direct store
+      ir += "c_direct_store:\n"
+      ir += generateDirectStoreCToDevice(
+        desc: desc, ldC: ldC,
+        cSramCount: cSramCount
+      )
+      ir += "  br label %exit\n\n"
+
+      // Slow path: TG → async copy (edge threadgroups)
+      ir += "c_slow_store:\n"
+    }
+
+    // Store C registers to TG block at offset 0 (no cmd area needed anymore)
+    ir += generateStoreCToTGInline(
+      desc: desc, ldC: ldC,
+      cSramCount: cSramCount,
+      M_group: M_group, N_group: N_group
+    )
+
+    // Barrier so all threads finish writing to TG before async store
+    ir += "  call void @air.wg.barrier(i32 2, i32 1)\n\n"
+
+    // Inline async store: TG → device (gated to sidx == 0)
+    ir += "  br i1 %is_sidx0, label %cs_do_store, label %cs_skip_store\n\n"
+    ir += "cs_do_store:\n"
+    ir += generateInlineStoreC(
+      desc: desc, ldC: ldC,
+      M_group: M_group, N_group: N_group
+    )
+    // generateInlineStoreC ends with br to exit, so no fall-through needed
+    ir += "cs_skip_store:\n"
+    ir += "  call void @air.wg.barrier(i32 2, i32 1)\n"
+    ir += "  br label %exit\n\n"
+
+    // Exit
+    ir += """
+
+    exit:
+      call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %ev_i8) #4
+      ret void
+    }
+
+    """
+
+    // Metadata
+    ir += irGEMMKernelMetadata() + "\n"
+
+    return ir
+  }
+
+  // MARK: - Inline Async Copy (A+B)
+
+  /// Generate inline dual async copy: A and B from device → TG.
+  /// All parameters are computed statically (no TG cmd area).
+  private func generateInlineDualCopy(
+    prefix p: String,
+    kStart: UInt32, kTile: UInt32,
+    ldA: UInt32, ldB: UInt32,
+    M_group: UInt16, N_group: UInt16, K_group: UInt16,
+    blockBytesA: Int,
+    M: UInt32, N: UInt32
+  ) -> String {
+    let memA_size = UInt32(memoryPrecisions.A.size)
+    let memB_size = UInt32(memoryPrecisions.B.size)
+
+    var ir = "  ; === Async copy iter \(p) (k=\(kStart)) ===\n"
+
+    // A source offset: apply_offset(A, ldA, (kStart, M_offset), A_trans)
+    if transposeState.A {
+      ir += "  %\(p)a_row = mul i32 \(kStart), \(ldA)\n"
+      ir += "  %\(p)a_off32 = add i32 %\(p)a_row, %M_offset\n"
+    } else {
+      ir += "  %\(p)a_row = mul i32 %M_offset, \(ldA)\n"
+      ir += "  %\(p)a_off32 = add i32 %\(p)a_row, \(kStart)\n"
+    }
+    ir += "  %\(p)a_off = zext i32 %\(p)a_off32 to i64\n"
+    ir += "  %\(p)a_byte = mul i64 %\(p)a_off, \(memA_size)\n"
+    ir += "  %\(p)a_src_p = getelementptr i8, i8 addrspace(1)* %A, i64 %\(p)a_byte\n"
+
+    // A tile dimensions (clamped)
+    let aMTile = min(UInt32(M_group), M)
+
+    // A dst/src strides
+    let aDstStride = UInt32(leadingBlockDimensions.A) * memA_size
+    let aSrcStride = ldA * memA_size
+
+    // Tile dims for async copy (src tile = actual data, dst tile = full block for zero-padding)
+    let (aSrcW, aSrcH, aDstW, aDstH): (String, String, UInt32, UInt32)
+    if transposeState.A {
+      aSrcW = "\(aMTile * memA_size)"  // width in bytes
+      aSrcH = "\(kTile)"
+      aDstW = UInt32(M_group) * memA_size
+      aDstH = UInt32(K_group)
+    } else {
+      aSrcW = "\(kTile * memA_size)"
+      aSrcH = "\(aMTile)"
+      aDstW = UInt32(K_group) * memA_size
+      aDstH = UInt32(M_group)
+    }
+
+    // A dst ptr = tg_base + 0 (A block starts at beginning of TG data area)
+    ir += "  %\(p)a_dst_p = getelementptr i8, i8 addrspace(3)* %tg_base, i64 0\n"
+
+    // Build tile vectors
+    ir += "  %\(p)a_stile_w = insertelement <2 x i64> zeroinitializer, i64 \(aSrcW), i32 0\n"
+    ir += "  %\(p)a_stile = insertelement <2 x i64> %\(p)a_stile_w, i64 \(aSrcH), i32 1\n"
+    ir += "  %\(p)a_dtile_w = insertelement <2 x i64> zeroinitializer, i64 \(aDstW), i32 0\n"
+    ir += "  %\(p)a_dtile = insertelement <2 x i64> %\(p)a_dtile_w, i64 \(aDstH), i32 1\n"
+
+    // Event pointer
+    ir += "  %\(p)ev0p = getelementptr [2 x %event_t addrspace(3)*], [2 x %event_t addrspace(3)*]* %ev, i64 0, i64 0\n"
+
+    // A async copy call
+    ir += """
+      %\(p)a_ev = call %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p3i8.p1i8(
+        i64 1, i64 1,
+        i8 addrspace(3)* %\(p)a_dst_p, i64 \(aDstStride), i64 1, <2 x i64> %\(p)a_dtile,
+        i8 addrspace(1)* %\(p)a_src_p, i64 \(aSrcStride), i64 1, <2 x i64> %\(p)a_stile,
+        <2 x i64> zeroinitializer, i32 0
+      )
+      store %event_t addrspace(3)* %\(p)a_ev, %event_t addrspace(3)** %\(p)ev0p
+
+    """
+
+    // B source offset: apply_offset(B, ldB, (N_offset, kStart), B_trans)
+    if transposeState.B {
+      ir += "  %\(p)b_row = mul i32 %N_offset, \(ldB)\n"
+      ir += "  %\(p)b_off32 = add i32 %\(p)b_row, \(kStart)\n"
+    } else {
+      ir += "  %\(p)b_row = mul i32 \(kStart), \(ldB)\n"
+      ir += "  %\(p)b_off32 = add i32 %\(p)b_row, %N_offset\n"
+    }
+    ir += "  %\(p)b_off = zext i32 %\(p)b_off32 to i64\n"
+    ir += "  %\(p)b_byte = mul i64 %\(p)b_off, \(memB_size)\n"
+    ir += "  %\(p)b_src_p = getelementptr i8, i8 addrspace(1)* %B, i64 %\(p)b_byte\n"
+
+    let bNTile = min(UInt32(N_group), N)
+    let bDstStride = UInt32(leadingBlockDimensions.B) * memB_size
+    let bSrcStride = ldB * memB_size
+
+    let (bSrcW, bSrcH, bDstW, bDstH): (String, String, UInt32, UInt32)
+    if transposeState.B {
+      bSrcW = "\(kTile * memB_size)"
+      bSrcH = "\(bNTile)"
+      bDstW = UInt32(K_group) * memB_size
+      bDstH = UInt32(N_group)
+    } else {
+      bSrcW = "\(bNTile * memB_size)"
+      bSrcH = "\(kTile)"
+      bDstW = UInt32(N_group) * memB_size
+      bDstH = UInt32(K_group)
+    }
+
+    // B dst ptr = tg_base + blockBytesA
+    ir += "  %\(p)b_dst_p = getelementptr i8, i8 addrspace(3)* %tg_base, i64 \(blockBytesA)\n"
+
+    ir += "  %\(p)b_stile_w = insertelement <2 x i64> zeroinitializer, i64 \(bSrcW), i32 0\n"
+    ir += "  %\(p)b_stile = insertelement <2 x i64> %\(p)b_stile_w, i64 \(bSrcH), i32 1\n"
+    ir += "  %\(p)b_dtile_w = insertelement <2 x i64> zeroinitializer, i64 \(bDstW), i32 0\n"
+    ir += "  %\(p)b_dtile = insertelement <2 x i64> %\(p)b_dtile_w, i64 \(bDstH), i32 1\n"
+
+    ir += "  %\(p)ev1p = getelementptr [2 x %event_t addrspace(3)*], [2 x %event_t addrspace(3)*]* %ev, i64 0, i64 1\n"
+
+    ir += """
+      %\(p)b_ev = call %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p3i8.p1i8(
+        i64 1, i64 1,
+        i8 addrspace(3)* %\(p)b_dst_p, i64 \(bDstStride), i64 1, <2 x i64> %\(p)b_dtile,
+        i8 addrspace(1)* %\(p)b_src_p, i64 \(bSrcStride), i64 1, <2 x i64> %\(p)b_stile,
+        <2 x i64> zeroinitializer, i32 0
+      )
+      store %event_t addrspace(3)* %\(p)b_ev, %event_t addrspace(3)** %\(p)ev1p
+
+    """
+
+    // Wait for both copies
+    ir += "  call void @air.wait_simdgroup_events(i32 2, %event_t addrspace(3)** %\(p)ev0p)\n"
+
+    return ir
+  }
+
+  // MARK: - Inline TG Multiply
+
+  /// Result of inline TG multiply generation.
+  struct InlineTGMultiplyResult {
+    var ir: String
+    var outputNames: [String]  // new C accumulator SSA names
+  }
+
+  /// Generate multiply-accumulate from TG data for one K-group iteration.
+  /// C accumulators are passed in and out via SSA names (no TG save/restore).
+  private func generateInlineTGMultiply(
+    prefix p: String,
+    kSteps: Int,
+    regM: UInt16, regN: UInt16,
+    blockBytesA: Int,
+    cSramCount: Int,
+    cInputNames: [String]
+  ) -> InlineTGMultiplyResult {
+    let regA = registerPrecisions.A
+    let regB = registerPrecisions.B
+    let regC = registerPrecisions.C
+    let memA = memoryPrecisions.A
+    let memB = memoryPrecisions.B
+    let ldBlockA = leadingBlockDimensions.A
+    let ldBlockB = leadingBlockDimensions.B
+
+    var ir = ""
+    ir += "  ; Multiply from TG (\(p))\n"
+    ir += "  br i1 %out_of_bounds, label %\(p)skip_mul, label %\(p)do_mul\n\n"
+    ir += "\(p)do_mul:\n"
+
+    // TG block pointers (A at offset 0, B at offset blockBytesA)
+    ir += "  %\(p)a_blk = getelementptr i8, i8 addrspace(3)* %tg_base, i64 0\n"
+    ir += "  %\(p)b_blk = getelementptr i8, i8 addrspace(3)* %tg_base, i64 \(blockBytesA)\n"
+
+    for k in 0..<kSteps {
+      let kOff = k * 8
+
+      // Load A tiles
+      for m in stride(from: 0, to: Int(regM), by: 8) {
+        let aElemType = irTypeName(memA)
+        let aElemSize = memA.size
+
+        if transposeState.A {
+          for elem in 0..<2 {
+            ir += "  %\(p)a_trow_\(k)_\(m)_\(elem) = add i32 %morton_x, \(kOff + elem)\n"
+            ir += "  %\(p)a_tcol_\(k)_\(m)_\(elem) = add i32 %oig_y, \(m)\n"
+            ir += "  %\(p)a_taddr_\(k)_\(m)_\(elem) = mul i32 %\(p)a_trow_\(k)_\(m)_\(elem), \(ldBlockA)\n"
+            ir += "  %\(p)a_taddr2_\(k)_\(m)_\(elem) = add i32 %\(p)a_taddr_\(k)_\(m)_\(elem), %\(p)a_tcol_\(k)_\(m)_\(elem)\n"
+            ir += "  %\(p)a_tbyte_\(k)_\(m)_\(elem) = mul i32 %\(p)a_taddr2_\(k)_\(m)_\(elem), \(aElemSize)\n"
+            ir += "  %\(p)a_tbyte64_\(k)_\(m)_\(elem) = zext i32 %\(p)a_tbyte_\(k)_\(m)_\(elem) to i64\n"
+            ir += "  %\(p)a_tptr_\(k)_\(m)_\(elem) = getelementptr i8, i8 addrspace(3)* %\(p)a_blk, i64 %\(p)a_tbyte64_\(k)_\(m)_\(elem)\n"
+            ir += "  %\(p)a_ttyped_\(k)_\(m)_\(elem) = bitcast i8 addrspace(3)* %\(p)a_tptr_\(k)_\(m)_\(elem) to \(aElemType) addrspace(3)*\n"
+            ir += "  %\(p)a_tload_\(k)_\(m)_\(elem) = load \(aElemType), \(aElemType) addrspace(3)* %\(p)a_ttyped_\(k)_\(m)_\(elem)\n"
+          }
+          if memA != regA {
+            for elem in 0..<2 {
+              ir += "  %\(p)a_text_\(k)_\(m)_\(elem) = fpext \(aElemType) %\(p)a_tload_\(k)_\(m)_\(elem) to \(irTypeName(regA))\n"
+            }
+            ir += "  %\(p)a_v2_\(k)_\(m) = insertelement <2 x \(irTypeName(regA))> undef, \(irTypeName(regA)) %\(p)a_text_\(k)_\(m)_0, i32 0\n"
+            ir += "  %\(p)a_v2b_\(k)_\(m) = insertelement <2 x \(irTypeName(regA))> %\(p)a_v2_\(k)_\(m), \(irTypeName(regA)) %\(p)a_text_\(k)_\(m)_1, i32 1\n"
+          } else {
+            ir += "  %\(p)a_v2_\(k)_\(m) = insertelement <2 x \(aElemType)> undef, \(aElemType) %\(p)a_tload_\(k)_\(m)_0, i32 0\n"
+            ir += "  %\(p)a_v2b_\(k)_\(m) = insertelement <2 x \(aElemType)> %\(p)a_v2_\(k)_\(m), \(aElemType) %\(p)a_tload_\(k)_\(m)_1, i32 1\n"
+          }
+          ir += irShuffleToVec64(result: "%\(p)a_sram_\(k)_\(m)", src: "%\(p)a_v2b_\(k)_\(m)", type: regA) + "\n"
+        } else {
+          ir += "  %\(p)a_row_\(k)_\(m) = add i32 %oig_y, \(m)\n"
+          ir += "  %\(p)a_col_\(k)_\(m) = add i32 %morton_x, \(kOff)\n"
+          ir += "  %\(p)a_addr_\(k)_\(m) = mul i32 %\(p)a_row_\(k)_\(m), \(ldBlockA)\n"
+          ir += "  %\(p)a_addr2_\(k)_\(m) = add i32 %\(p)a_addr_\(k)_\(m), %\(p)a_col_\(k)_\(m)\n"
+          ir += "  %\(p)a_byte_\(k)_\(m) = mul i32 %\(p)a_addr2_\(k)_\(m), \(aElemSize)\n"
+          ir += "  %\(p)a_byte64_\(k)_\(m) = zext i32 %\(p)a_byte_\(k)_\(m) to i64\n"
+          ir += "  %\(p)a_ptr_\(k)_\(m) = getelementptr i8, i8 addrspace(3)* %\(p)a_blk, i64 %\(p)a_byte64_\(k)_\(m)\n"
+          ir += "  %\(p)a_typed_\(k)_\(m) = bitcast i8 addrspace(3)* %\(p)a_ptr_\(k)_\(m) to <2 x \(aElemType)> addrspace(3)*\n"
+          ir += "  %\(p)a_load_\(k)_\(m) = load <2 x \(aElemType)>, <2 x \(aElemType)> addrspace(3)* %\(p)a_typed_\(k)_\(m), align \(aElemSize * 2)\n"
+
+          if memA != regA {
+            ir += "  %\(p)a_cvt0_\(k)_\(m) = extractelement <2 x \(aElemType)> %\(p)a_load_\(k)_\(m), i32 0\n"
+            ir += "  %\(p)a_cvt1_\(k)_\(m) = extractelement <2 x \(aElemType)> %\(p)a_load_\(k)_\(m), i32 1\n"
+            ir += "  %\(p)a_ext0_\(k)_\(m) = fpext \(aElemType) %\(p)a_cvt0_\(k)_\(m) to \(irTypeName(regA))\n"
+            ir += "  %\(p)a_ext1_\(k)_\(m) = fpext \(aElemType) %\(p)a_cvt1_\(k)_\(m) to \(irTypeName(regA))\n"
+            ir += "  %\(p)a_v2_\(k)_\(m) = insertelement <2 x \(irTypeName(regA))> undef, \(irTypeName(regA)) %\(p)a_ext0_\(k)_\(m), i32 0\n"
+            ir += "  %\(p)a_v2b_\(k)_\(m) = insertelement <2 x \(irTypeName(regA))> %\(p)a_v2_\(k)_\(m), \(irTypeName(regA)) %\(p)a_ext1_\(k)_\(m), i32 1\n"
+            ir += irShuffleToVec64(result: "%\(p)a_sram_\(k)_\(m)", src: "%\(p)a_v2b_\(k)_\(m)", type: regA) + "\n"
+          } else {
+            ir += irShuffleToVec64(result: "%\(p)a_sram_\(k)_\(m)", src: "%\(p)a_load_\(k)_\(m)", type: regA) + "\n"
+          }
+        }
+      }
+
+      // Load B tiles
+      for n in stride(from: 0, to: Int(regN), by: 8) {
+        let bElemType = irTypeName(memB)
+        let bElemSize = memB.size
+
+        if transposeState.B {
+          for elem in 0..<2 {
+            ir += "  %\(p)b_trow_\(k)_\(n)_\(elem) = add i32 %oig_x, \(n + elem)\n"
+            ir += "  %\(p)b_tcol_\(k)_\(n)_\(elem) = add i32 %morton_y, \(kOff)\n"
+            ir += "  %\(p)b_taddr_\(k)_\(n)_\(elem) = mul i32 %\(p)b_trow_\(k)_\(n)_\(elem), \(ldBlockB)\n"
+            ir += "  %\(p)b_taddr2_\(k)_\(n)_\(elem) = add i32 %\(p)b_taddr_\(k)_\(n)_\(elem), %\(p)b_tcol_\(k)_\(n)_\(elem)\n"
+            ir += "  %\(p)b_tbyte_\(k)_\(n)_\(elem) = mul i32 %\(p)b_taddr2_\(k)_\(n)_\(elem), \(bElemSize)\n"
+            ir += "  %\(p)b_tbyte64_\(k)_\(n)_\(elem) = zext i32 %\(p)b_tbyte_\(k)_\(n)_\(elem) to i64\n"
+            ir += "  %\(p)b_tptr_\(k)_\(n)_\(elem) = getelementptr i8, i8 addrspace(3)* %\(p)b_blk, i64 %\(p)b_tbyte64_\(k)_\(n)_\(elem)\n"
+            ir += "  %\(p)b_ttyped_\(k)_\(n)_\(elem) = bitcast i8 addrspace(3)* %\(p)b_tptr_\(k)_\(n)_\(elem) to \(bElemType) addrspace(3)*\n"
+            ir += "  %\(p)b_tload_\(k)_\(n)_\(elem) = load \(bElemType), \(bElemType) addrspace(3)* %\(p)b_ttyped_\(k)_\(n)_\(elem)\n"
+          }
+          if memB != regB {
+            for elem in 0..<2 {
+              ir += "  %\(p)b_text_\(k)_\(n)_\(elem) = fpext \(bElemType) %\(p)b_tload_\(k)_\(n)_\(elem) to \(irTypeName(regB))\n"
+            }
+            ir += "  %\(p)b_v2_\(k)_\(n) = insertelement <2 x \(irTypeName(regB))> undef, \(irTypeName(regB)) %\(p)b_text_\(k)_\(n)_0, i32 0\n"
+            ir += "  %\(p)b_v2b_\(k)_\(n) = insertelement <2 x \(irTypeName(regB))> %\(p)b_v2_\(k)_\(n), \(irTypeName(regB)) %\(p)b_text_\(k)_\(n)_1, i32 1\n"
+          } else {
+            ir += "  %\(p)b_v2_\(k)_\(n) = insertelement <2 x \(bElemType)> undef, \(bElemType) %\(p)b_tload_\(k)_\(n)_0, i32 0\n"
+            ir += "  %\(p)b_v2b_\(k)_\(n) = insertelement <2 x \(bElemType)> %\(p)b_v2_\(k)_\(n), \(bElemType) %\(p)b_tload_\(k)_\(n)_1, i32 1\n"
+          }
+          ir += irShuffleToVec64(result: "%\(p)b_sram_\(k)_\(n)", src: "%\(p)b_v2b_\(k)_\(n)", type: regB) + "\n"
+        } else {
+          ir += "  %\(p)b_row_\(k)_\(n) = add i32 %morton_y, \(kOff)\n"
+          ir += "  %\(p)b_col_\(k)_\(n) = add i32 %oig_x, \(n)\n"
+          ir += "  %\(p)b_addr_\(k)_\(n) = mul i32 %\(p)b_row_\(k)_\(n), \(ldBlockB)\n"
+          ir += "  %\(p)b_addr2_\(k)_\(n) = add i32 %\(p)b_addr_\(k)_\(n), %\(p)b_col_\(k)_\(n)\n"
+          ir += "  %\(p)b_byte_\(k)_\(n) = mul i32 %\(p)b_addr2_\(k)_\(n), \(bElemSize)\n"
+          ir += "  %\(p)b_byte64_\(k)_\(n) = zext i32 %\(p)b_byte_\(k)_\(n) to i64\n"
+          ir += "  %\(p)b_ptr_\(k)_\(n) = getelementptr i8, i8 addrspace(3)* %\(p)b_blk, i64 %\(p)b_byte64_\(k)_\(n)\n"
+          ir += "  %\(p)b_typed_\(k)_\(n) = bitcast i8 addrspace(3)* %\(p)b_ptr_\(k)_\(n) to <2 x \(bElemType)> addrspace(3)*\n"
+          ir += "  %\(p)b_load_\(k)_\(n) = load <2 x \(bElemType)>, <2 x \(bElemType)> addrspace(3)* %\(p)b_typed_\(k)_\(n), align \(bElemSize * 2)\n"
+
+          if memB != regB {
+            ir += "  %\(p)b_cvt0_\(k)_\(n) = extractelement <2 x \(bElemType)> %\(p)b_load_\(k)_\(n), i32 0\n"
+            ir += "  %\(p)b_cvt1_\(k)_\(n) = extractelement <2 x \(bElemType)> %\(p)b_load_\(k)_\(n), i32 1\n"
+            ir += "  %\(p)b_ext0_\(k)_\(n) = fpext \(bElemType) %\(p)b_cvt0_\(k)_\(n) to \(irTypeName(regB))\n"
+            ir += "  %\(p)b_ext1_\(k)_\(n) = fpext \(bElemType) %\(p)b_cvt1_\(k)_\(n) to \(irTypeName(regB))\n"
+            ir += "  %\(p)b_v2_\(k)_\(n) = insertelement <2 x \(irTypeName(regB))> undef, \(irTypeName(regB)) %\(p)b_ext0_\(k)_\(n), i32 0\n"
+            ir += "  %\(p)b_v2b_\(k)_\(n) = insertelement <2 x \(irTypeName(regB))> %\(p)b_v2_\(k)_\(n), \(irTypeName(regB)) %\(p)b_ext1_\(k)_\(n), i32 1\n"
+            ir += irShuffleToVec64(result: "%\(p)b_sram_\(k)_\(n)", src: "%\(p)b_v2b_\(k)_\(n)", type: regB) + "\n"
+          } else {
+            ir += irShuffleToVec64(result: "%\(p)b_sram_\(k)_\(n)", src: "%\(p)b_load_\(k)_\(n)", type: regB) + "\n"
+          }
+        }
+      }
+
+      // Multiply-accumulate: for each (m, n) pair
+      for m in stride(from: 0, to: Int(regM), by: 8) {
+        for n in stride(from: 0, to: Int(regN), by: 8) {
+          let cIdx = (m / 8) * (Int(regN) / 8) + (n / 8)
+          let cIn = (k == 0) ? cInputNames[cIdx] : "%\(p)c_ma_\(k-1)_\(m)_\(n)"
+          let cOut = "%\(p)c_ma_\(k)_\(m)_\(n)"
+
+          ir += irMultiplyAccumulateCall(
+            result: cOut,
+            A: ("%\(p)a_sram_\(k)_\(m)", regA),
+            B: ("%\(p)b_sram_\(k)_\(n)", regB),
+            C: (cIn, regC)
+          ) + "\n"
+        }
+      }
+    }
+
+    ir += "  br label %\(p)after_mul\n\n"
+    ir += "\(p)skip_mul:\n"
+    ir += "  br label %\(p)after_mul\n\n"
+    ir += "\(p)after_mul:\n"
+
+    // Phi nodes to merge C values
+    var outputNames = [String]()
+    for m in stride(from: 0, to: Int(regM), by: 8) {
+      for n in stride(from: 0, to: Int(regN), by: 8) {
+        let cIdx = (m / 8) * (Int(regN) / 8) + (n / 8)
+        let lastK = kSteps - 1
+        let outName = "%\(p)c_out_\(cIdx)"
+        ir += "  \(outName) = phi \(irVecType(regC)) [%\(p)c_ma_\(lastK)_\(m)_\(n), %\(p)do_mul], [\(cInputNames[cIdx]), %\(p)skip_mul]\n"
+        outputNames.append(outName)
+      }
+    }
+    ir += "\n"
+
+    return InlineTGMultiplyResult(ir: ir, outputNames: outputNames)
+  }
+
+  // MARK: - Inline C Store
+
+  /// Store C registers to TG block then inline async copy TG → device.
+  /// Uses a single OOB branch instead of per-tile branches.
+  private func generateStoreCToTGInline(
+    desc: MonolithicDescriptor,
+    ldC: UInt32,
+    cSramCount: Int,
+    M_group: UInt16, N_group: UInt16
+  ) -> String {
+    let memC = memoryPrecisions.C
+    let regC = registerPrecisions.C
+    let elemSize = memC.size
+
+    var ir = "  ; Store C registers to TG block\n"
+
+    // Single OOB branch for all tile stores
+    ir += "  br i1 %out_of_bounds, label %c_skip_all_stores, label %c_do_all_stores\n\n"
+    ir += "c_do_all_stores:\n"
+    ir += "  %c_store_base = getelementptr i8, i8 addrspace(3)* %tg_base, i64 0\n"
+
+    for m in stride(from: 0, to: Int(registerM), by: 8) {
+      for n in stride(from: 0, to: Int(registerN), by: 8) {
+        let cIdx = (m / 8) * (Int(registerN) / 8) + (n / 8)
+
+        ir += irShuffleFromVec64(result: "%c_st_\(cIdx)", src: "%c_final_\(cIdx)", type: regC) + "\n"
+
+        if regC != memC {
+          ir += "  %c_st_e0_\(cIdx) = extractelement <2 x \(irTypeName(regC))> %c_st_\(cIdx), i32 0\n"
+          ir += "  %c_st_e1_\(cIdx) = extractelement <2 x \(irTypeName(regC))> %c_st_\(cIdx), i32 1\n"
+          ir += "  %c_st_trunc0_\(cIdx) = fptrunc \(irTypeName(regC)) %c_st_e0_\(cIdx) to \(irTypeName(memC))\n"
+          ir += "  %c_st_trunc1_\(cIdx) = fptrunc \(irTypeName(regC)) %c_st_e1_\(cIdx) to \(irTypeName(memC))\n"
+          ir += "  %c_st_mem_\(cIdx)_a = insertelement <2 x \(irTypeName(memC))> undef, \(irTypeName(memC)) %c_st_trunc0_\(cIdx), i32 0\n"
+          ir += "  %c_st_mem_\(cIdx) = insertelement <2 x \(irTypeName(memC))> %c_st_mem_\(cIdx)_a, \(irTypeName(memC)) %c_st_trunc1_\(cIdx), i32 1\n"
+        }
+
+        let storeVec = (regC != memC) ? "%c_st_mem_\(cIdx)" : "%c_st_\(cIdx)"
+        let storeType = irTypeName(memC)
+
+        ir += "  %c_tg_row_\(cIdx) = add i32 %oig_y, \(m)\n"
+        ir += "  %c_tg_addr_\(cIdx) = mul i32 %c_tg_row_\(cIdx), \(leadingBlockDimensions.C)\n"
+        ir += "  %c_tg_col_\(cIdx) = add i32 %oig_x, \(n)\n"
+        ir += "  %c_tg_addr2_\(cIdx) = add i32 %c_tg_addr_\(cIdx), %c_tg_col_\(cIdx)\n"
+        ir += "  %c_tg_byte_\(cIdx) = mul i32 %c_tg_addr2_\(cIdx), \(elemSize)\n"
+        ir += "  %c_tg_byte64_\(cIdx) = zext i32 %c_tg_byte_\(cIdx) to i64\n"
+
+        ir += "  %c_tg_ptr_\(cIdx) = getelementptr i8, i8 addrspace(3)* %c_store_base, i64 %c_tg_byte64_\(cIdx)\n"
+        ir += "  %c_tg_typed_\(cIdx) = bitcast i8 addrspace(3)* %c_tg_ptr_\(cIdx) to <2 x \(storeType)> addrspace(3)*\n"
+        ir += "  store <2 x \(storeType)> \(storeVec), <2 x \(storeType)> addrspace(3)* %c_tg_typed_\(cIdx)\n"
+      }
+    }
+
+    ir += "  br label %c_skip_all_stores\n\n"
+    ir += "c_skip_all_stores:\n"
+
+    return ir
+  }
+
+  /// Direct store: C registers → device memory (fast path, no TG).
+  /// Each thread stores its <2 x T> directly to device via GEP + store.
+  /// Only valid for non-edge threadgroups where all M_group × N_group elements
+  /// are in bounds and no edge shift occurred.
+  private func generateDirectStoreCToDevice(
+    desc: MonolithicDescriptor,
+    ldC: UInt32,
+    cSramCount: Int
+  ) -> String {
+    let memC = memoryPrecisions.C
+    let regC = registerPrecisions.C
+    let elemSize = UInt32(memC.size)
+
+    var ir = "  ; Direct store C: registers → device\n"
+
+    for m in stride(from: 0, to: Int(registerM), by: 8) {
+      for n in stride(from: 0, to: Int(registerN), by: 8) {
+        let cIdx = (m / 8) * (Int(registerN) / 8) + (n / 8)
+
+        // Unshuffle from <64 x T> to <2 x T>
+        ir += irShuffleFromVec64(result: "%cd_v2_\(cIdx)", src: "%c_final_\(cIdx)", type: regC) + "\n"
+
+        // Precision conversion if needed
+        if regC != memC {
+          ir += "  %cd_e0_\(cIdx) = extractelement <2 x \(irTypeName(regC))> %cd_v2_\(cIdx), i32 0\n"
+          ir += "  %cd_e1_\(cIdx) = extractelement <2 x \(irTypeName(regC))> %cd_v2_\(cIdx), i32 1\n"
+          ir += "  %cd_trunc0_\(cIdx) = fptrunc \(irTypeName(regC)) %cd_e0_\(cIdx) to \(irTypeName(memC))\n"
+          ir += "  %cd_trunc1_\(cIdx) = fptrunc \(irTypeName(regC)) %cd_e1_\(cIdx) to \(irTypeName(memC))\n"
+          ir += "  %cd_mem_\(cIdx)_a = insertelement <2 x \(irTypeName(memC))> undef, \(irTypeName(memC)) %cd_trunc0_\(cIdx), i32 0\n"
+          ir += "  %cd_mem_\(cIdx) = insertelement <2 x \(irTypeName(memC))> %cd_mem_\(cIdx)_a, \(irTypeName(memC)) %cd_trunc1_\(cIdx), i32 1\n"
+        }
+
+        let storeVec = (regC != memC) ? "%cd_mem_\(cIdx)" : "%cd_v2_\(cIdx)"
+        let storeType = irTypeName(memC)
+
+        // Device address: C + (M_offset + oig_y + m) * ldC + (N_offset + oig_x + n)
+        ir += "  %cd_row_\(cIdx) = add i32 %M_offset, %oig_y\n"
+        ir += "  %cd_row2_\(cIdx) = add i32 %cd_row_\(cIdx), \(m)\n"
+        ir += "  %cd_col_\(cIdx) = add i32 %N_offset, %oig_x\n"
+        ir += "  %cd_col2_\(cIdx) = add i32 %cd_col_\(cIdx), \(n)\n"
+        ir += "  %cd_off_\(cIdx) = mul i32 %cd_row2_\(cIdx), \(ldC)\n"
+        ir += "  %cd_off2_\(cIdx) = add i32 %cd_off_\(cIdx), %cd_col2_\(cIdx)\n"
+        ir += "  %cd_off64_\(cIdx) = zext i32 %cd_off2_\(cIdx) to i64\n"
+        ir += "  %cd_byte_\(cIdx) = mul i64 %cd_off64_\(cIdx), \(elemSize)\n"
+        ir += "  %cd_ptr_\(cIdx) = getelementptr i8, i8 addrspace(1)* %C, i64 %cd_byte_\(cIdx)\n"
+        ir += "  %cd_typed_\(cIdx) = bitcast i8 addrspace(1)* %cd_ptr_\(cIdx) to <2 x \(storeType)> addrspace(1)*\n"
+        ir += "  store <2 x \(storeType)> \(storeVec), <2 x \(storeType)> addrspace(1)* %cd_typed_\(cIdx)\n"
+      }
+    }
+
+    return ir
+  }
+
+  /// Inline async store: C from TG → device (no cmd protocol).
+  private func generateInlineStoreC(
+    desc: MonolithicDescriptor,
+    ldC: UInt32,
+    M_group: UInt16, N_group: UInt16
+  ) -> String {
+    let elemSize = UInt32(memoryPrecisions.C.size)
+
+    var ir = "  ; Inline async store C: TG → device\n"
+
+    // Use UNSHIFTED offsets for device address (same as old code)
+    ir += "  %c_dev_m_unshift = mul i32 %gid_y, \(M_group)\n"
+    ir += "  %c_dev_n_unshift = mul i32 %gid_x, \(N_group)\n"
+    ir += "  %c_dev_row = mul i32 %c_dev_m_unshift, \(ldC)\n"
+    ir += "  %c_dev_off32 = add i32 %c_dev_row, %c_dev_n_unshift\n"
+    ir += "  %c_dev_off = zext i32 %c_dev_off32 to i64\n"
+    ir += "  %c_dev_byte = mul i64 %c_dev_off, \(elemSize)\n"
+
+    // Tile dimensions
+    ir += "  %c_tile_n = sub i32 \(desc.N), %c_dev_n_unshift\n"
+    ir += "  %c_tile_n_cmp = icmp ult i32 %c_tile_n, \(N_group)\n"
+    ir += "  %c_tile_w32 = select i1 %c_tile_n_cmp, i32 %c_tile_n, i32 \(N_group)\n"
+    ir += "  %c_tile_w_bytes32 = mul i32 %c_tile_w32, \(elemSize)\n"
+    ir += "  %c_tile_w_bytes = zext i32 %c_tile_w_bytes32 to i64\n"
+
+    ir += "  %c_tile_m = sub i32 \(desc.M), %c_dev_m_unshift\n"
+    ir += "  %c_tile_m_cmp = icmp ult i32 %c_tile_m, \(M_group)\n"
+    ir += "  %c_tile_h32 = select i1 %c_tile_m_cmp, i32 %c_tile_m, i32 \(M_group)\n"
+    ir += "  %c_tile_h = zext i32 %c_tile_h32 to i64\n"
+
+    // TG source pointer with edge shift
+    let M_edge = desc.M - (desc.M % UInt32(M_group))
+    let N_edge = desc.N - (desc.N % UInt32(N_group))
+    let M_remainder_store = (desc.M % UInt32(registerM) == 0) ? registerM : UInt16(desc.M % UInt32(registerM))
+    let N_remainder_store = (desc.N % UInt32(registerN) == 0) ? registerN : UInt16(desc.N % UInt32(registerN))
+    let M_shift_val: UInt16 = (desc.M < UInt32(M_group)) ? 0 : registerM - M_remainder_store
+    let N_shift_val: UInt16 = (desc.N < UInt32(N_group)) ? 0 : registerN - N_remainder_store
+
+    if M_shift_val != 0 || N_shift_val != 0 {
+      ir += "  ; TG block shift for edge correction\n"
+      if M_shift_val != 0 {
+        ir += "  %cs_m_edge_cmp = icmp uge i32 %c_dev_m_unshift, \(M_edge)\n"
+        ir += "  %cs_m_shift = select i1 %cs_m_edge_cmp, i32 \(M_shift_val), i32 0\n"
+      } else {
+        ir += "  %cs_m_shift = add i32 0, 0\n"
+      }
+      if N_shift_val != 0 {
+        ir += "  %cs_n_edge_cmp = icmp uge i32 %c_dev_n_unshift, \(N_edge)\n"
+        ir += "  %cs_n_shift = select i1 %cs_n_edge_cmp, i32 \(N_shift_val), i32 0\n"
+      } else {
+        ir += "  %cs_n_shift = add i32 0, 0\n"
+      }
+      ir += "  %cs_tg_shift_row = mul i32 %cs_m_shift, \(leadingBlockDimensions.C)\n"
+      ir += "  %cs_tg_shift_off = add i32 %cs_tg_shift_row, %cs_n_shift\n"
+      ir += "  %cs_tg_shift_bytes = mul i32 %cs_tg_shift_off, \(elemSize)\n"
+      ir += "  %cs_tg_off32 = add i32 0, %cs_tg_shift_bytes\n"
+      ir += "  %cs_tg_off = zext i32 %cs_tg_off32 to i64\n"
+    } else {
+      ir += "  %cs_tg_off = add i64 0, 0\n"
+    }
+
+    let dstStride = ldC * elemSize
+    let srcStride = UInt32(leadingBlockDimensions.C) * elemSize
+
+    ir += "  %cs_dst_p = getelementptr i8, i8 addrspace(1)* %C, i64 %c_dev_byte\n"
+    ir += "  %cs_src_p = getelementptr i8, i8 addrspace(3)* %tg_base, i64 %cs_tg_off\n"
+
+    ir += "  %cs_tile_w = insertelement <2 x i64> zeroinitializer, i64 %c_tile_w_bytes, i32 0\n"
+    ir += "  %cs_tile = insertelement <2 x i64> %cs_tile_w, i64 %c_tile_h, i32 1\n"
+
+    ir += "  %cs_evp = getelementptr [2 x %event_t addrspace(3)*], [2 x %event_t addrspace(3)*]* %ev, i64 0, i64 0\n"
+
+    ir += """
+      %cs_ev = call %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p1i8.p3i8(
+        i64 1, i64 1,
+        i8 addrspace(1)* %cs_dst_p, i64 \(dstStride), i64 1, <2 x i64> %cs_tile,
+        i8 addrspace(3)* %cs_src_p, i64 \(srcStride), i64 1, <2 x i64> %cs_tile,
+        <2 x i64> zeroinitializer, i32 0
+      )
+      store %event_t addrspace(3)* %cs_ev, %event_t addrspace(3)** %cs_evp
+      call void @air.wait_simdgroup_events(i32 1, %event_t addrspace(3)** %cs_evp)
+      call void @air.wg.barrier(i32 2, i32 1)
+      br label %exit
+
+    """
+
+    return ir
+  }
+
+  // MARK: - Inline Load C (for loadPreviousC)
+
+  /// Inline async load of previous C from device → TG, then load into registers.
+  private func generateInlineLoadC(
+    desc: MonolithicDescriptor,
+    ldC: UInt32,
+    M_group: UInt16, N_group: UInt16,
+    cSramCount: Int
+  ) -> String {
+    let memC = memoryPrecisions.C
+    let regC = registerPrecisions.C
+    let elemSize = UInt32(memC.size)
+
+    var ir = "  ; === Load previous C ===\n"
+
+    // Device offset for C
+    ir += "  %lpc_dev_row = mul i32 %M_offset, \(ldC)\n"
+    ir += "  %lpc_dev_off32 = add i32 %lpc_dev_row, %N_offset\n"
+    ir += "  %lpc_dev_off = zext i32 %lpc_dev_off32 to i64\n"
+    ir += "  %lpc_dev_byte = mul i64 %lpc_dev_off, \(elemSize)\n"
+
+    // Tile dimensions
+    ir += "  %lpc_n_rem = sub i32 \(desc.N), %N_offset\n"
+    ir += "  %lpc_n_cmp = icmp ult i32 %lpc_n_rem, \(N_group)\n"
+    ir += "  %lpc_tw32 = select i1 %lpc_n_cmp, i32 %lpc_n_rem, i32 \(N_group)\n"
+    ir += "  %lpc_tw_bytes32 = mul i32 %lpc_tw32, \(elemSize)\n"
+    ir += "  %lpc_tw = zext i32 %lpc_tw_bytes32 to i64\n"
+
+    ir += "  %lpc_m_rem = sub i32 \(desc.M), %M_offset\n"
+    ir += "  %lpc_m_cmp = icmp ult i32 %lpc_m_rem, \(M_group)\n"
+    ir += "  %lpc_th32 = select i1 %lpc_m_cmp, i32 %lpc_m_rem, i32 \(M_group)\n"
+    ir += "  %lpc_th = zext i32 %lpc_th32 to i64\n"
+
+    let dstStride = UInt32(leadingBlockDimensions.C) * elemSize
+    let srcStride = ldC * elemSize
+
+    ir += "  %lpc_src_p = getelementptr i8, i8 addrspace(1)* %C, i64 %lpc_dev_byte\n"
+    ir += "  %lpc_dst_p = getelementptr i8, i8 addrspace(3)* %tg_base, i64 0\n"
+
+    ir += "  %lpc_tile_w = insertelement <2 x i64> zeroinitializer, i64 %lpc_tw, i32 0\n"
+    ir += "  %lpc_tile = insertelement <2 x i64> %lpc_tile_w, i64 %lpc_th, i32 1\n"
+
+    ir += "  %lpc_evp = getelementptr [2 x %event_t addrspace(3)*], [2 x %event_t addrspace(3)*]* %ev, i64 0, i64 0\n"
+
+    // Gate async copy to sidx == 0
+    ir += "  br i1 %is_sidx0, label %lpc_do_copy, label %lpc_skip_copy\n\n"
+    ir += "lpc_do_copy:\n"
+    ir += """
+      %lpc_ev = call %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p3i8.p1i8(
+        i64 1, i64 1,
+        i8 addrspace(3)* %lpc_dst_p, i64 \(dstStride), i64 1, <2 x i64> %lpc_tile,
+        i8 addrspace(1)* %lpc_src_p, i64 \(srcStride), i64 1, <2 x i64> %lpc_tile,
+        <2 x i64> zeroinitializer, i32 0
+      )
+      store %event_t addrspace(3)* %lpc_ev, %event_t addrspace(3)** %lpc_evp
+      call void @air.wait_simdgroup_events(i32 1, %event_t addrspace(3)** %lpc_evp)
+      br label %lpc_after_copy
+
+    """
+    ir += "lpc_skip_copy:\n"
+    ir += "  br label %lpc_after_copy\n\n"
+    ir += "lpc_after_copy:\n"
+    ir += "  call void @air.wg.barrier(i32 2, i32 1)\n\n"
+
+    // Load C from TG into accumulators
+    ir += "  %lc_base = getelementptr i8, i8 addrspace(3)* %tg_base, i64 0\n"
+
+    for m in stride(from: 0, to: Int(registerM), by: 8) {
+      for n in stride(from: 0, to: Int(registerN), by: 8) {
+        let cIdx = (m / 8) * (Int(registerN) / 8) + (n / 8)
+
+        ir += "  %lc_row_\(cIdx) = add i32 %oig_y, \(m)\n"
+        ir += "  %lc_addr_\(cIdx) = mul i32 %lc_row_\(cIdx), \(leadingBlockDimensions.C)\n"
+        ir += "  %lc_col_\(cIdx) = add i32 %oig_x, \(n)\n"
+        ir += "  %lc_addr2_\(cIdx) = add i32 %lc_addr_\(cIdx), %lc_col_\(cIdx)\n"
+        ir += "  %lc_byte_\(cIdx) = mul i32 %lc_addr2_\(cIdx), \(memC.size)\n"
+        ir += "  %lc_byte64_\(cIdx) = zext i32 %lc_byte_\(cIdx) to i64\n"
+
+        ir += "  br i1 %out_of_bounds, label %lc_skip_\(cIdx), label %lc_do_\(cIdx)\n\n"
+
+        ir += "lc_do_\(cIdx):\n"
+        ir += "  %lc_ptr_\(cIdx) = getelementptr i8, i8 addrspace(3)* %lc_base, i64 %lc_byte64_\(cIdx)\n"
+        ir += "  %lc_typed_\(cIdx) = bitcast i8 addrspace(3)* %lc_ptr_\(cIdx) to <2 x \(irTypeName(memC))> addrspace(3)*\n"
+        ir += "  %lc_load_\(cIdx) = load <2 x \(irTypeName(memC))>, <2 x \(irTypeName(memC))> addrspace(3)* %lc_typed_\(cIdx), align \(memC.size * 2)\n"
+
+        if memC != regC {
+          ir += "  %lc_e0_\(cIdx) = extractelement <2 x \(irTypeName(memC))> %lc_load_\(cIdx), i32 0\n"
+          ir += "  %lc_e1_\(cIdx) = extractelement <2 x \(irTypeName(memC))> %lc_load_\(cIdx), i32 1\n"
+          ir += "  %lc_ext0_\(cIdx) = fpext \(irTypeName(memC)) %lc_e0_\(cIdx) to \(irTypeName(regC))\n"
+          ir += "  %lc_ext1_\(cIdx) = fpext \(irTypeName(memC)) %lc_e1_\(cIdx) to \(irTypeName(regC))\n"
+          ir += "  %lc_v2_\(cIdx) = insertelement <2 x \(irTypeName(regC))> undef, \(irTypeName(regC)) %lc_ext0_\(cIdx), i32 0\n"
+          ir += "  %lc_v2b_\(cIdx) = insertelement <2 x \(irTypeName(regC))> %lc_v2_\(cIdx), \(irTypeName(regC)) %lc_ext1_\(cIdx), i32 1\n"
+          ir += irShuffleToVec64(result: "%lc_loaded_\(cIdx)", src: "%lc_v2b_\(cIdx)", type: regC) + "\n"
+        } else {
+          ir += irShuffleToVec64(result: "%lc_loaded_\(cIdx)", src: "%lc_load_\(cIdx)", type: regC) + "\n"
+        }
+        ir += "  br label %lc_skip_\(cIdx)\n\n"
+
+        // The OOB branch comes from the block containing `br i1 %out_of_bounds`:
+        // for cIdx==0, that's "lpc_after_copy"; for cIdx>0, it's "lc_skip_(cIdx-1)"
+        ir += "lc_skip_\(cIdx):\n"
+        let oobSource = (cIdx == 0) ? "lpc_after_copy" : "lc_skip_\(cIdx - 1)"
+        ir += "  %c_start_\(cIdx) = phi \(irVecType(regC)) [%lc_loaded_\(cIdx), %lc_do_\(cIdx)], [%c_init_\(cIdx), %\(oobSource)]\n"
+      }
+    }
+
+    // Barrier before A/B copies reuse TG
+    ir += "  call void @air.wg.barrier(i32 2, i32 1)\n\n"
+
+    return ir
   }
 }

--- a/Sources/FlashAttention/Utilities/IRTemplate.swift
+++ b/Sources/FlashAttention/Utilities/IRTemplate.swift
@@ -1,0 +1,558 @@
+//
+//  IRTemplate.swift
+//  FlashAttention
+//
+//  Parameterized helpers for generating LLVM IR text for monolithic
+//  Metal compute kernels assembled via MetalASM.
+//
+//  These templates replace the shell+visible-function reverse-linking
+//  pattern with a single monolithic kernel containing dispatch loop,
+//  async copy, and compute body inlined together.
+//
+
+// MARK: - Module Structure
+
+/// Generate the LLVM IR module header: datalayout, triple, event_t type,
+/// and threadgroup buffer global.
+///
+/// - Parameter tgBufferFloats: Size of threadgroup buffer in 32-bit words.
+func irModuleHeader(tgBufferFloats: Int = 8192) -> String {
+  _ = tgBufferFloats
+  return """
+  source_filename = "monolithic_gemm"
+  target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024-n8:16:32"
+  target triple = "air64_v28-apple-macosx26.0.0"
+
+  %event_t = type opaque
+  """
+}
+
+/// Generate intrinsic declarations for async copy, barrier, wait, and lifetime.
+func irIntrinsicDeclarations() -> String {
+  """
+
+  declare %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p3i8.p1i8(i64, i64, i8 addrspace(3)*, i64, i64, <2 x i64>, i8 addrspace(1)*, i64, i64, <2 x i64>, <2 x i64>, i32) #1
+  declare %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p1i8.p3i8(i64, i64, i8 addrspace(1)*, i64, i64, <2 x i64>, i8 addrspace(3)*, i64, i64, <2 x i64>, <2 x i64>, i32) #1
+  declare void @air.wait_simdgroup_events(i32, %event_t addrspace(3)**) #1
+  declare void @air.wg.barrier(i32, i32) #1
+  declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
+  declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
+  """
+}
+
+// MARK: - Multiply-Accumulate Intrinsics
+
+/// The LLVM IR type name for a precision.
+func irTypeName(_ precision: GEMMOperandPrecision) -> String {
+  switch precision {
+  case .FP32: return "float"
+  case .FP16: return "half"
+  case .BF16: return "bfloat"
+  }
+}
+
+/// The LLVM IR vector type for a 64-element simdgroup matrix.
+func irVecType(_ precision: GEMMOperandPrecision) -> String {
+  return "<64 x \(irTypeName(precision))>"
+}
+
+/// The mangled suffix for a simdgroup matrix vector type.
+func irVecSuffix(_ precision: GEMMOperandPrecision) -> String {
+  switch precision {
+  case .FP32: return "v64f32"
+  case .FP16: return "v64f16"
+  case .BF16: return "v64bf16"
+  }
+}
+
+/// Generate the multiply_accumulate intrinsic declaration for given precisions.
+///
+/// - Parameters:
+///   - A: Precision of left operand
+///   - B: Precision of right operand
+///   - C: Precision of accumulator (also return type)
+func irMultiplyAccumulateDeclaration(
+  A: GEMMOperandPrecision,
+  B: GEMMOperandPrecision,
+  C: GEMMOperandPrecision
+) -> String {
+  let retSuffix = irVecSuffix(C)
+  let aSuffix = irVecSuffix(A)
+  let bSuffix = irVecSuffix(B)
+  let cSuffix = irVecSuffix(C)
+  let name = "@air.simdgroup_matrix_8x8_multiply_accumulate.\(retSuffix).\(aSuffix).\(bSuffix).\(cSuffix)"
+  return "declare \(irVecType(C)) \(name)(\(irVecType(A)), \(irVecType(B)), \(irVecType(C))) local_unnamed_addr #1"
+}
+
+/// Generate a call to the multiply_accumulate intrinsic.
+///
+/// Returns the SSA name of the result.
+func irMultiplyAccumulateCall(
+  result: String,
+  A: (name: String, precision: GEMMOperandPrecision),
+  B: (name: String, precision: GEMMOperandPrecision),
+  C: (name: String, precision: GEMMOperandPrecision)
+) -> String {
+  let retSuffix = irVecSuffix(C.precision)
+  let aSuffix = irVecSuffix(A.precision)
+  let bSuffix = irVecSuffix(B.precision)
+  let cSuffix = irVecSuffix(C.precision)
+  let intrinsicName = "@air.simdgroup_matrix_8x8_multiply_accumulate.\(retSuffix).\(aSuffix).\(bSuffix).\(cSuffix)"
+  return "  \(result) = tail call fast \(irVecType(C.precision)) \(intrinsicName)(\(irVecType(A.precision)) \(A.name), \(irVecType(B.precision)) \(B.name), \(irVecType(C.precision)) \(C.name)) #3"
+}
+
+// MARK: - Vector Element Transfer Patterns
+
+/// Generate IR to place 2 elements from a <2 x T> into a <64 x T> vector.
+/// Uses insertelement (avoids shufflevector with vector constant masks
+/// that MetalASM's parser doesn't support).
+///
+/// Produces 3 lines of IR: extract e0, extract e1, insert e0 at 0, insert e1 at 1.
+/// The result name gets `_e0`, `_e1`, `_v0` suffixes for intermediates.
+func irShuffleToVec64(result: String, src: String, type: GEMMOperandPrecision) -> String {
+  let t = irTypeName(type)
+  let v64 = "<64 x \(t)>"
+  var ir = ""
+  ir += "  \(result)_e0 = extractelement <2 x \(t)> \(src), i32 0\n"
+  ir += "  \(result)_e1 = extractelement <2 x \(t)> \(src), i32 1\n"
+  ir += "  \(result)_v0 = insertelement \(v64) undef, \(t) \(result)_e0, i32 0\n"
+  ir += "  \(result) = insertelement \(v64) \(result)_v0, \(t) \(result)_e1, i32 1"
+  return ir
+}
+
+/// Generate IR to extract first 2 elements from a <64 x T> into a <2 x T>.
+/// Uses extractelement + insertelement.
+func irShuffleFromVec64(result: String, src: String, type: GEMMOperandPrecision) -> String {
+  let t = irTypeName(type)
+  var ir = ""
+  ir += "  \(result)_e0 = extractelement <64 x \(t)> \(src), i32 0\n"
+  ir += "  \(result)_e1 = extractelement <64 x \(t)> \(src), i32 1\n"
+  ir += "  \(result)_v0 = insertelement <2 x \(t)> undef, \(t) \(result)_e0, i32 0\n"
+  ir += "  \(result) = insertelement <2 x \(t)> \(result)_v0, \(t) \(result)_e1, i32 1"
+  return ir
+}
+
+/// Generate IR to create a named zero <64 x T> vector via bitcast.
+/// Returns a full instruction line (no leading spaces, no trailing newline).
+/// Usage: `ir += "  " + irZeroVec64(result: "%c_sram_0", precision: .FP32) + "\n"`
+func irZeroVec64(result: String, precision: GEMMOperandPrecision) -> String {
+  let v = irVecType(precision)
+  return "\(result) = bitcast \(v) zeroinitializer to \(v)"
+}
+
+// MARK: - Address Space Helpers
+
+/// Address spaces in Metal AIR.
+enum IRAddressSpace: Int {
+  case thread_ = 0
+  case device = 1
+  case constant = 2
+  case threadgroup = 3
+}
+
+/// Generate a GEP (getelementptr) for an i32 index into threadgroup cmd area.
+func irCmdLoad(result: String, cmdBase: String, index: Int) -> String {
+  """
+    \(result)_ptr = getelementptr i32, i32 addrspace(3)* \(cmdBase), i64 \(index)
+    \(result) = load i32, i32 addrspace(3)* \(result)_ptr
+  """
+}
+
+// MARK: - Dual Async Copy Block
+
+/// Generate the dual async copy block (A+B from device to threadgroup).
+/// This reads copy parameters from the threadgroup command area and executes
+/// two `air.simdgroup_async_copy_2d` calls.
+///
+/// - Parameters:
+///   - bufferA: SSA name of buffer A (i8 addrspace(1)*)
+///   - bufferB: SSA name of buffer B (i8 addrspace(1)*)
+///   - evAlloca: SSA name of the event array alloca
+///   - tgBase: SSA name of threadgroup base pointer (i8 addrspace(3)*)
+///   - tgCmd: SSA name of threadgroup command pointer (i32 addrspace(3)*)
+///   - resumeResult: SSA name for the next resume point value
+///   - resumeInput: SSA name of the current resume point
+func irDualCopyBlock(
+  label: String = "do_dual_copy",
+  bufferA: String = "%A",
+  bufferB: String = "%B",
+  evAlloca: String = "%ev",
+  tgBase: String = "%tg_base",
+  tgCmd: String = "%tg_cmd",
+  resumeResult: String = "%nr_d",
+  resumeInput: String = "%resume_point"
+) -> String {
+  """
+  \(label):
+    ; ── A copy params ──
+    %a1 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 1
+    %a_dst_s32 = load i32, i32 addrspace(3)* %a1
+    %a_dst_s = zext i32 %a_dst_s32 to i64
+    %a2 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 2
+    %a_src_s32 = load i32, i32 addrspace(3)* %a2
+    %a_src_s = zext i32 %a_src_s32 to i64
+    %a3 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 3
+    %a_stw32 = load i32, i32 addrspace(3)* %a3
+    %a_stw = zext i32 %a_stw32 to i64
+    %a4 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 4
+    %a_sth32 = load i32, i32 addrspace(3)* %a4
+    %a_sth = zext i32 %a_sth32 to i64
+    %a5 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 5
+    %a_off_lo = load i32, i32 addrspace(3)* %a5
+    %a6 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 6
+    %a_off_hi = load i32, i32 addrspace(3)* %a6
+    %a_off_lo64 = zext i32 %a_off_lo to i64
+    %a_off_hi64 = zext i32 %a_off_hi to i64
+    %a_off_hi_s = shl i64 %a_off_hi64, 32
+    %a_off = or i64 %a_off_lo64, %a_off_hi_s
+    %a7 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 7
+    %a_tg_off32 = load i32, i32 addrspace(3)* %a7
+    %a_tg_off = zext i32 %a_tg_off32 to i64
+    %a21 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 21
+    %a_dtw32 = load i32, i32 addrspace(3)* %a21
+    %a_dtw = zext i32 %a_dtw32 to i64
+    %a22 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 22
+    %a_dth32 = load i32, i32 addrspace(3)* %a22
+    %a_dth = zext i32 %a_dth32 to i64
+    %a_sv0 = insertelement <2 x i64> zeroinitializer, i64 %a_stw, i32 0
+    %a_stile = insertelement <2 x i64> %a_sv0, i64 %a_sth, i32 1
+    %a_dv0 = insertelement <2 x i64> zeroinitializer, i64 %a_dtw, i32 0
+    %a_dtile = insertelement <2 x i64> %a_dv0, i64 %a_dth, i32 1
+    %a_src_p = getelementptr i8, i8 addrspace(1)* \(bufferA), i64 %a_off
+    %a_dst_p = getelementptr i8, i8 addrspace(3)* \(tgBase), i64 %a_tg_off
+    %ev0p = getelementptr [2 x %event_t addrspace(3)*], [2 x %event_t addrspace(3)*]* \(evAlloca), i64 0, i64 0
+    %a_ev = call %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p3i8.p1i8(
+      i64 1, i64 1,
+      i8 addrspace(3)* %a_dst_p, i64 %a_dst_s, i64 1, <2 x i64> %a_dtile,
+      i8 addrspace(1)* %a_src_p, i64 %a_src_s, i64 1, <2 x i64> %a_stile,
+      <2 x i64> zeroinitializer, i32 0
+    )
+    store %event_t addrspace(3)* %a_ev, %event_t addrspace(3)** %ev0p
+    ; ── B copy ──
+    %b11 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 11
+    %b_dst_s32 = load i32, i32 addrspace(3)* %b11
+    %b_dst_s = zext i32 %b_dst_s32 to i64
+    %b12 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 12
+    %b_src_s32 = load i32, i32 addrspace(3)* %b12
+    %b_src_s = zext i32 %b_src_s32 to i64
+    %b13 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 13
+    %b_stw32 = load i32, i32 addrspace(3)* %b13
+    %b_stw = zext i32 %b_stw32 to i64
+    %b14 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 14
+    %b_sth32 = load i32, i32 addrspace(3)* %b14
+    %b_sth = zext i32 %b_sth32 to i64
+    %b15 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 15
+    %b_off_lo = load i32, i32 addrspace(3)* %b15
+    %b16 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 16
+    %b_off_hi = load i32, i32 addrspace(3)* %b16
+    %b_off_lo64 = zext i32 %b_off_lo to i64
+    %b_off_hi64 = zext i32 %b_off_hi to i64
+    %b_off_hi_s = shl i64 %b_off_hi64, 32
+    %b_off = or i64 %b_off_lo64, %b_off_hi_s
+    %b17 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 17
+    %b_tg_off32 = load i32, i32 addrspace(3)* %b17
+    %b_tg_off = zext i32 %b_tg_off32 to i64
+    %b23 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 23
+    %b_dtw32 = load i32, i32 addrspace(3)* %b23
+    %b_dtw = zext i32 %b_dtw32 to i64
+    %b24 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 24
+    %b_dth32 = load i32, i32 addrspace(3)* %b24
+    %b_dth = zext i32 %b_dth32 to i64
+    %b_sv0 = insertelement <2 x i64> zeroinitializer, i64 %b_stw, i32 0
+    %b_stile = insertelement <2 x i64> %b_sv0, i64 %b_sth, i32 1
+    %b_dv0 = insertelement <2 x i64> zeroinitializer, i64 %b_dtw, i32 0
+    %b_dtile = insertelement <2 x i64> %b_dv0, i64 %b_dth, i32 1
+    %b_src_p = getelementptr i8, i8 addrspace(1)* \(bufferB), i64 %b_off
+    %b_dst_p = getelementptr i8, i8 addrspace(3)* \(tgBase), i64 %b_tg_off
+    %ev1p = getelementptr [2 x %event_t addrspace(3)*], [2 x %event_t addrspace(3)*]* \(evAlloca), i64 0, i64 1
+    %b_ev = call %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p3i8.p1i8(
+      i64 1, i64 1,
+      i8 addrspace(3)* %b_dst_p, i64 %b_dst_s, i64 1, <2 x i64> %b_dtile,
+      i8 addrspace(1)* %b_src_p, i64 %b_src_s, i64 1, <2 x i64> %b_stile,
+      <2 x i64> zeroinitializer, i32 0
+    )
+    store %event_t addrspace(3)* %b_ev, %event_t addrspace(3)** %ev1p
+    ; Wait for both
+    call void @air.wait_simdgroup_events(i32 2, %event_t addrspace(3)** %ev0p)
+    call void @air.wg.barrier(i32 2, i32 1)
+    \(resumeResult) = add i32 \(resumeInput), 1
+    br label %after_async
+  """
+}
+
+// MARK: - Single Load Block
+
+/// Generate the single async copy (device → threadgroup) block.
+func irSingleLoadBlock(
+  label: String = "do_single_load",
+  buffer: String = "%C",
+  evAlloca: String = "%ev",
+  tgBase: String = "%tg_base",
+  tgCmd: String = "%tg_cmd",
+  resumeResult: String = "%nr_l",
+  resumeInput: String = "%resume_point"
+) -> String {
+  """
+  \(label):
+    %l1 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 1
+    %l_dst_s32 = load i32, i32 addrspace(3)* %l1
+    %l_dst_s = zext i32 %l_dst_s32 to i64
+    %l2 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 2
+    %l_src_s32 = load i32, i32 addrspace(3)* %l2
+    %l_src_s = zext i32 %l_src_s32 to i64
+    %l3 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 3
+    %l_tw32 = load i32, i32 addrspace(3)* %l3
+    %l_tw = zext i32 %l_tw32 to i64
+    %l4 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 4
+    %l_th32 = load i32, i32 addrspace(3)* %l4
+    %l_th = zext i32 %l_th32 to i64
+    %l5 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 5
+    %l_off_lo = load i32, i32 addrspace(3)* %l5
+    %l6 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 6
+    %l_off_hi = load i32, i32 addrspace(3)* %l6
+    %l_off_lo64 = zext i32 %l_off_lo to i64
+    %l_off_hi64 = zext i32 %l_off_hi to i64
+    %l_off_hi_s = shl i64 %l_off_hi64, 32
+    %l_off = or i64 %l_off_lo64, %l_off_hi_s
+    %l7 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 7
+    %l_tg_off32 = load i32, i32 addrspace(3)* %l7
+    %l_tg_off = zext i32 %l_tg_off32 to i64
+    %l_src_p = getelementptr i8, i8 addrspace(1)* \(buffer), i64 %l_off
+    %l_dst_p = getelementptr i8, i8 addrspace(3)* \(tgBase), i64 %l_tg_off
+    %l_v0 = insertelement <2 x i64> zeroinitializer, i64 %l_tw, i32 0
+    %l_tile = insertelement <2 x i64> %l_v0, i64 %l_th, i32 1
+    %l_evp = getelementptr [2 x %event_t addrspace(3)*], [2 x %event_t addrspace(3)*]* \(evAlloca), i64 0, i64 0
+    %l_ev = call %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p3i8.p1i8(
+      i64 1, i64 1,
+      i8 addrspace(3)* %l_dst_p, i64 %l_dst_s, i64 1, <2 x i64> %l_tile,
+      i8 addrspace(1)* %l_src_p, i64 %l_src_s, i64 1, <2 x i64> %l_tile,
+      <2 x i64> zeroinitializer, i32 0
+    )
+    store %event_t addrspace(3)* %l_ev, %event_t addrspace(3)** %l_evp
+    call void @air.wait_simdgroup_events(i32 1, %event_t addrspace(3)** %l_evp)
+    call void @air.wg.barrier(i32 2, i32 1)
+    \(resumeResult) = add i32 \(resumeInput), 1
+    br label %after_async
+  """
+}
+
+// MARK: - Single Store Block
+
+/// Generate the single async copy (threadgroup → device) block.
+func irSingleStoreBlock(
+  label: String = "do_single_store",
+  buffer: String = "%C",
+  evAlloca: String = "%ev",
+  tgBase: String = "%tg_base",
+  tgCmd: String = "%tg_cmd",
+  resumeResult: String = "%nr_s",
+  resumeInput: String = "%resume_point"
+) -> String {
+  """
+  \(label):
+    %s1 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 1
+    %s_dst_s32 = load i32, i32 addrspace(3)* %s1
+    %s_dst_s = zext i32 %s_dst_s32 to i64
+    %s2 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 2
+    %s_src_s32 = load i32, i32 addrspace(3)* %s2
+    %s_src_s = zext i32 %s_src_s32 to i64
+    %s3 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 3
+    %s_tw32 = load i32, i32 addrspace(3)* %s3
+    %s_tw = zext i32 %s_tw32 to i64
+    %s4 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 4
+    %s_th32 = load i32, i32 addrspace(3)* %s4
+    %s_th = zext i32 %s_th32 to i64
+    %s5 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 5
+    %s_off_lo = load i32, i32 addrspace(3)* %s5
+    %s6 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 6
+    %s_off_hi = load i32, i32 addrspace(3)* %s6
+    %s_off_lo64 = zext i32 %s_off_lo to i64
+    %s_off_hi64 = zext i32 %s_off_hi to i64
+    %s_off_hi_s = shl i64 %s_off_hi64, 32
+    %s_off = or i64 %s_off_lo64, %s_off_hi_s
+    %s7 = getelementptr i32, i32 addrspace(3)* \(tgCmd), i64 7
+    %s_tg_off32 = load i32, i32 addrspace(3)* %s7
+    %s_tg_off = zext i32 %s_tg_off32 to i64
+    %s_dst_p = getelementptr i8, i8 addrspace(1)* \(buffer), i64 %s_off
+    %s_src_p = getelementptr i8, i8 addrspace(3)* \(tgBase), i64 %s_tg_off
+    %s_v0 = insertelement <2 x i64> zeroinitializer, i64 %s_tw, i32 0
+    %s_tile = insertelement <2 x i64> %s_v0, i64 %s_th, i32 1
+    %s_evp = getelementptr [2 x %event_t addrspace(3)*], [2 x %event_t addrspace(3)*]* \(evAlloca), i64 0, i64 0
+    %s_ev = call %event_t addrspace(3)* @air.simdgroup_async_copy_2d.p1i8.p3i8(
+      i64 1, i64 1,
+      i8 addrspace(1)* %s_dst_p, i64 %s_dst_s, i64 1, <2 x i64> %s_tile,
+      i8 addrspace(3)* %s_src_p, i64 %s_src_s, i64 1, <2 x i64> %s_tile,
+      <2 x i64> zeroinitializer, i32 0
+    )
+    store %event_t addrspace(3)* %s_ev, %event_t addrspace(3)** %s_evp
+    call void @air.wait_simdgroup_events(i32 1, %event_t addrspace(3)** %s_evp)
+    call void @air.wg.barrier(i32 2, i32 1)
+    \(resumeResult) = add i32 \(resumeInput), 1
+    br label %after_async
+  """
+}
+
+// MARK: - Dispatch Loop Skeleton
+
+/// Generate the dispatch loop that sits between compute blocks and
+/// async copy blocks. Reads cmd[0] and branches to the appropriate
+/// copy block or exit.
+///
+/// The compute body blocks should branch to `dispatch_loop` when they
+/// need an async copy, after writing params to the cmd area.
+func irDispatchLoopAndAfterAsync() -> String {
+  """
+
+  after_async:
+    %next_resume = phi i32 [%nr_d, %do_dual_copy], [%nr_l, %do_single_load], [%nr_s, %do_single_store]
+    br label %dispatch_loop
+  """
+}
+
+// MARK: - Kernel Metadata
+
+/// Generate metadata for a GEMM kernel with 3 device buffers (A, B, C)
+/// plus system values (gid, sidx, lane_id).
+///
+/// - Parameters:
+///   - kernelName: The kernel function name
+///   - functionRef: The LLVM IR function signature type string
+func irGEMMKernelMetadata(kernelName: String = "gemm") -> String {
+  """
+
+  attributes #0 = { convergent mustprogress nounwind willreturn "frame-pointer"="none" "min-legal-vector-width"="96" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+  attributes #1 = { convergent mustprogress nounwind willreturn }
+  attributes #2 = { argmemonly mustprogress nocallback nofree nosync nounwind willreturn }
+  attributes #3 = { convergent nounwind willreturn }
+  attributes #4 = { nounwind }
+
+  !air.kernel = !{!0}
+  !llvm.module.flags = !{!8, !9, !10, !11, !12, !13, !14}
+  !air.compile_options = !{!15, !16, !17}
+  !llvm.ident = !{!19}
+  !air.version = !{!20}
+  !air.language_version = !{!21}
+  !air.source_file_name = !{!22}
+
+  !0 = !{void (i8 addrspace(1)*, i8 addrspace(1)*, i8 addrspace(1)*, i8 addrspace(3)*, <3 x i32>, i16, i16)* @\(kernelName), !1, !2}
+  !1 = !{}
+  !2 = !{!3, !4, !5, !31, !30, !6, !7}
+  !3 = !{i32 0, !"air.buffer", !"air.location_index", i32 0, i32 1, !"air.read", !"air.address_space", i32 1, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"A"}
+  !4 = !{i32 1, !"air.buffer", !"air.location_index", i32 1, i32 1, !"air.read", !"air.address_space", i32 1, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"B"}
+  !5 = !{i32 2, !"air.buffer", !"air.location_index", i32 2, i32 1, !"air.read_write", !"air.address_space", i32 1, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"C"}
+  !31 = !{i32 3, !"air.buffer", !"air.location_index", i32 0, i32 1, !"air.read_write", !"air.address_space", i32 3, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"tg_mem"}
+  !30 = !{i32 4, !"air.threadgroup_position_in_grid", !"air.arg_type_name", !"uint3", !"air.arg_name", !"gid"}
+  !6 = !{i32 5, !"air.simdgroup_index_in_threadgroup", !"air.arg_type_name", !"ushort", !"air.arg_name", !"sidx"}
+  !7 = !{i32 6, !"air.thread_index_in_simdgroup", !"air.arg_type_name", !"ushort", !"air.arg_name", !"lane_id"}
+
+  !8 = !{i32 1, !"wchar_size", i32 4}
+  !9 = !{i32 7, !"air.max_device_buffers", i32 31}
+  !10 = !{i32 7, !"air.max_constant_buffers", i32 31}
+  !11 = !{i32 7, !"air.max_threadgroup_buffers", i32 31}
+  !12 = !{i32 7, !"air.max_textures", i32 128}
+  !13 = !{i32 7, !"air.max_read_write_textures", i32 8}
+  !14 = !{i32 7, !"air.max_samplers", i32 16}
+  !15 = !{!"air.compile.denorms_disable"}
+  !16 = !{!"air.compile.fast_math_enable"}
+  !17 = !{!"air.compile.framebuffer_fetch_enable"}
+  !19 = !{!"MetalASM (monolithic GEMM)"}
+  !20 = !{i32 2, i32 8, i32 0}
+  !21 = !{!"Metal", i32 4, i32 0, i32 0}
+  !22 = !{!"monolithic_gemm.ll"}
+  """
+}
+
+// MARK: - Attention Intrinsics
+
+/// Additional intrinsic declarations needed for attention kernels:
+/// simd_shuffle_xor, exp2, log2.
+func irAttentionIntrinsicDeclarations() -> String {
+  """
+
+  declare float @air.simd_shuffle_xor.f32(float, i32) #1
+  declare float @llvm.exp2.f32(float) #1
+  declare float @llvm.log2.f32(float) #1
+  """
+}
+
+/// Generate a simd_shuffle_xor call.
+func irShuffleXorCall(
+  result: String, value: String, mask: Int
+) -> String {
+  "  \(result) = call float @air.simd_shuffle_xor.f32(float \(value), i32 \(mask))"
+}
+
+/// Generate a fast exp2 call.
+func irExp2Call(result: String, value: String) -> String {
+  "  \(result) = call fast float @llvm.exp2.f32(float \(value))"
+}
+
+/// Generate a fast log2 call.
+func irLog2Call(result: String, value: String) -> String {
+  "  \(result) = call fast float @llvm.log2.f32(float \(value))"
+}
+
+// MARK: - Attention Kernel Metadata
+
+/// Generate metadata for an attention kernel with 10 device buffers
+/// (Q, K, V, O, L, D, dO, dV, dK, dQ) plus 1 TG buffer + system values.
+///
+/// Buffer bindings:
+///   0: Q (read), 1: K (read), 2: V (read), 3: O (read_write),
+///   4: L (read_write), 5: D (read_write),
+///   6: dO (read), 7: dV (read_write), 8: dK (read_write), 9: dQ (read_write)
+func irAttentionKernelMetadata(kernelName: String = "attention") -> String {
+  // Build the function type signature: 10 device buffers + 1 TG + gid + sidx + lane_id
+  let ptrArgs = (0..<10).map { _ in "i8 addrspace(1)*" }.joined(separator: ", ")
+  let fnType = "void (\(ptrArgs), i8 addrspace(3)*, <3 x i32>, i16, i16)"
+
+  return """
+
+  attributes #0 = { convergent mustprogress nounwind willreturn "frame-pointer"="none" "min-legal-vector-width"="96" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+  attributes #1 = { convergent mustprogress nounwind willreturn }
+  attributes #2 = { argmemonly mustprogress nocallback nofree nosync nounwind willreturn }
+  attributes #3 = { convergent nounwind willreturn }
+  attributes #4 = { nounwind }
+
+  !air.kernel = !{!0}
+  !llvm.module.flags = !{!8, !9, !10, !11, !12, !13, !14}
+  !air.compile_options = !{!15, !16, !17}
+  !llvm.ident = !{!19}
+  !air.version = !{!20}
+  !air.language_version = !{!21}
+  !air.source_file_name = !{!22}
+
+  !0 = !{\(fnType)* @\(kernelName), !1, !2}
+  !1 = !{}
+  !2 = !{!30, !31, !32, !33, !34, !35, !36, !37, !38, !39, !40, !41, !42, !43}
+  !30 = !{i32 0, !"air.buffer", !"air.location_index", i32 0, i32 1, !"air.read", !"air.address_space", i32 1, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"Q"}
+  !31 = !{i32 1, !"air.buffer", !"air.location_index", i32 1, i32 1, !"air.read", !"air.address_space", i32 1, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"K"}
+  !32 = !{i32 2, !"air.buffer", !"air.location_index", i32 2, i32 1, !"air.read", !"air.address_space", i32 1, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"V"}
+  !33 = !{i32 3, !"air.buffer", !"air.location_index", i32 3, i32 1, !"air.read_write", !"air.address_space", i32 1, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"O"}
+  !34 = !{i32 4, !"air.buffer", !"air.location_index", i32 4, i32 1, !"air.read_write", !"air.address_space", i32 1, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"L"}
+  !35 = !{i32 5, !"air.buffer", !"air.location_index", i32 5, i32 1, !"air.read_write", !"air.address_space", i32 1, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"D_buf"}
+  !36 = !{i32 6, !"air.buffer", !"air.location_index", i32 6, i32 1, !"air.read", !"air.address_space", i32 1, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"dO"}
+  !37 = !{i32 7, !"air.buffer", !"air.location_index", i32 7, i32 1, !"air.read_write", !"air.address_space", i32 1, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"dV"}
+  !38 = !{i32 8, !"air.buffer", !"air.location_index", i32 8, i32 1, !"air.read_write", !"air.address_space", i32 1, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"dK"}
+  !39 = !{i32 9, !"air.buffer", !"air.location_index", i32 9, i32 1, !"air.read_write", !"air.address_space", i32 1, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"dQ"}
+  !40 = !{i32 10, !"air.buffer", !"air.location_index", i32 0, i32 1, !"air.read_write", !"air.address_space", i32 3, !"air.arg_type_size", i32 1, !"air.arg_type_align_size", i32 1, !"air.arg_type_name", !"uchar", !"air.arg_name", !"tg_mem"}
+  !41 = !{i32 11, !"air.threadgroup_position_in_grid", !"air.arg_type_name", !"uint3", !"air.arg_name", !"gid"}
+  !42 = !{i32 12, !"air.simdgroup_index_in_threadgroup", !"air.arg_type_name", !"ushort", !"air.arg_name", !"sidx"}
+  !43 = !{i32 13, !"air.thread_index_in_simdgroup", !"air.arg_type_name", !"ushort", !"air.arg_name", !"lane_id"}
+
+  !8 = !{i32 1, !"wchar_size", i32 4}
+  !9 = !{i32 7, !"air.max_device_buffers", i32 31}
+  !10 = !{i32 7, !"air.max_constant_buffers", i32 31}
+  !11 = !{i32 7, !"air.max_threadgroup_buffers", i32 31}
+  !12 = !{i32 7, !"air.max_textures", i32 128}
+  !13 = !{i32 7, !"air.max_read_write_textures", i32 8}
+  !14 = !{i32 7, !"air.max_samplers", i32 16}
+  !15 = !{!"air.compile.denorms_disable"}
+  !16 = !{!"air.compile.fast_math_enable"}
+  !17 = !{!"air.compile.framebuffer_fetch_enable"}
+  !19 = !{!"MetalASM (monolithic attention)"}
+  !20 = !{i32 2, i32 8, i32 0}
+  !21 = !{!"Metal", i32 4, i32 0, i32 0}
+  !22 = !{!"monolithic_attention.ll"}
+  """
+}

--- a/Tests/FlashAttentionTests/Attention/SquareAttentionTest.swift
+++ b/Tests/FlashAttentionTests/Attention/SquareAttentionTest.swift
@@ -220,9 +220,9 @@ private func validateProblemSize(
   networkDesc.columnDimension = sequenceDimension
   networkDesc.headDimension = headDimension
   let network = Network(descriptor: networkDesc)
-  
+
   // MARK: - Kernels
-  
+
   var attentionDesc = AttentionDescriptor()
   attentionDesc.lowPrecisionInputs = false
   attentionDesc.lowPrecisionIntermediates = false
@@ -231,39 +231,15 @@ private func validateProblemSize(
     column: UInt32(sequenceDimension),
     head: UInt16(headDimension))
   attentionDesc.transposeState = (Q: false, K: false, V: false, O: false)
-  
-  func createKernel(type: AttentionKernelType) -> AttentionKernel {
-    let attentionKernelDesc = attentionDesc.kernelDescriptor(type: type)
-    let attentionKernel = AttentionKernel(descriptor: attentionKernelDesc)
-    return attentionKernel
-  }
-  let kernelForward = createKernel(type: .forward)
-  let kernelBackwardQuery = createKernel(type: .backwardQuery)
-  let kernelBackwardKeyValue = createKernel(type: .backwardKeyValue)
-  
-  func createPipeline(kernel: AttentionKernel) -> MTLComputePipelineState {
-    let device = MTLContext.global.device
-    let source = kernel.createSource()
-    let library = try! device.makeLibrary(source: source, options: nil)
-    
-    let functionConstants = MTLFunctionConstantValues()
-    attentionDesc.setFunctionConstants(functionConstants)
-    let function = try! library.makeFunction(
-      name: "attention", constantValues: functionConstants)
-    
-    // A critical part of the heuristic: force the occupancy to 1024 on M1.
-    let pipelineDesc = MTLComputePipelineDescriptor()
-    pipelineDesc.computeFunction = function
-    pipelineDesc.maxTotalThreadsPerThreadgroup = 1024
-    return try! device.makeComputePipelineState(
-      descriptor: pipelineDesc, options: [], reflection: nil)
-  }
-  let pipelineForward = createPipeline(kernel: kernelForward)
-  let pipelineBackwardQuery = createPipeline(kernel: kernelBackwardQuery)
-  let pipelineBackwardKeyValue = createPipeline(kernel: kernelBackwardKeyValue)
-  
+
+  AttentionKernel.register(descriptor: attentionDesc)
+  let cache = AttentionKernel.pipelineCache[attentionDesc]!
+  let (kernelForward, pipelineForward) = cache[.forward]!
+  let (kernelBackwardQuery, pipelineBackwardQuery) = cache[.backwardQuery]!
+  let (kernelBackwardKeyValue, pipelineBackwardKeyValue) = cache[.backwardKeyValue]!
+
   // MARK: - Buffers
-  
+
   // Utility function to make buffer initialization more concise.
   func createBuffer(
     _ array: [Float],
@@ -275,7 +251,7 @@ private func validateProblemSize(
     }
     return MTLContext.global.createBuffer(array, precision)
   }
-  
+
   let operandSize = sequenceDimension * headDimension
   var resultO = [Float](repeating: .zero, count: operandSize)
   var resultL = [Float](repeating: .zero, count: sequenceDimension)
@@ -284,22 +260,23 @@ private func validateProblemSize(
   var resultDerivativeK = [Float](repeating: .zero, count: operandSize)
   var resultDerivativeQ = [Float](repeating: .zero, count: operandSize)
   resultO[0] = .nan
-  
+
+  // Create all 10 buffers (unused ones get a dummy 4-byte buffer).
   let bufferQ = createBuffer(network.Q, .Q)
   let bufferK = createBuffer(network.K, .K)
   let bufferV = createBuffer(network.V, .V)
   let bufferDerivativeO = createBuffer(network.dO, .dO)
-  
+
   let bufferL = createBuffer(resultL, .L)
   let bufferD = createBuffer(resultD, .D)
-  
+
   let bufferO = createBuffer(resultO, .O)
   let bufferDerivativeV = createBuffer(resultDerivativeV, .dV)
   let bufferDerivativeK = createBuffer(resultDerivativeK, .dK)
   let bufferDerivativeQ = createBuffer(resultDerivativeQ, .dQ)
-  
+
   // MARK: - GPU Commands
-  
+
   // - Parameter dispatchCount: Number of times to duplicate the FWD / BWD
   //                            combined pass.
   // - Returns: Latency of the entire command buffer, in seconds.
@@ -310,11 +287,11 @@ private func validateProblemSize(
     let commandQueue = MTLContext.global.commandQueue
     let commandBuffer = commandQueue.makeCommandBuffer()!
     let encoder = commandBuffer.makeComputeCommandEncoder()!
-    
+
     func ceilDivide(_ target: Int, _ granularity: UInt16) -> Int {
       (target + Int(granularity) - 1) / Int(granularity)
     }
-    
+
     // Bind all necessary MTLBuffer arguments before calling this function.
     func dispatch(
       kernel: AttentionKernel,
@@ -324,7 +301,7 @@ private func validateProblemSize(
       encoder.setComputePipelineState(pipeline)
       encoder.setThreadgroupMemoryLength(
         Int(kernel.threadgroupMemoryAllocation), index: 0)
-      
+
       let blockCount = ceilDivide(
         parallelizationDimension, kernel.blockDimensions.parallelization)
       let gridSize = MTLSize(
@@ -577,38 +554,14 @@ private func profileProblemSize(
     head: UInt16(headDimension))
   attentionDesc.transposeState = (Q: false, K: false, V: false, O: false)
   
-  func createKernel(type: AttentionKernelType) -> AttentionKernel {
-    let attentionKernelDesc = attentionDesc.kernelDescriptor(type: type)
-    let attentionKernel = AttentionKernel(descriptor: attentionKernelDesc)
-    return attentionKernel
-  }
-  let kernelForward = createKernel(type: .forward)
-  let kernelBackwardQuery = createKernel(type: .backwardQuery)
-  let kernelBackwardKeyValue = createKernel(type: .backwardKeyValue)
-  
-  func createPipeline(kernel: AttentionKernel) -> MTLComputePipelineState {
-    let device = MTLContext.global.device
-    let source = kernel.createSource()
-    let library = try! device.makeLibrary(source: source, options: nil)
-    
-    let functionConstants = MTLFunctionConstantValues()
-    attentionDesc.setFunctionConstants(functionConstants)
-    let function = try! library.makeFunction(
-      name: "attention", constantValues: functionConstants)
-    
-    // A critical part of the heuristic: force the occupancy to 1024 on M1.
-    let pipelineDesc = MTLComputePipelineDescriptor()
-    pipelineDesc.computeFunction = function
-    pipelineDesc.maxTotalThreadsPerThreadgroup = 1024
-    return try! device.makeComputePipelineState(
-      descriptor: pipelineDesc, options: [], reflection: nil)
-  }
-  let pipelineForward = createPipeline(kernel: kernelForward)
-  let pipelineBackwardQuery = createPipeline(kernel: kernelBackwardQuery)
-  let pipelineBackwardKeyValue = createPipeline(kernel: kernelBackwardKeyValue)
-  
+  AttentionKernel.register(descriptor: attentionDesc)
+  let cache = AttentionKernel.pipelineCache[attentionDesc]!
+  let (kernelForward, pipelineForward) = cache[.forward]!
+  let (kernelBackwardQuery, pipelineBackwardQuery) = cache[.backwardQuery]!
+  let (kernelBackwardKeyValue, pipelineBackwardKeyValue) = cache[.backwardKeyValue]!
+
   // MARK: - Buffers
-  
+
   // Utility function to make buffer initialization more concise.
   func createBuffer(
     _ array: [Float],
@@ -620,7 +573,7 @@ private func profileProblemSize(
     }
     return MTLContext.global.createBuffer(array, precision)
   }
-  
+
   let operandSize = sequenceDimension * headDimension
   var resultO = [Float](repeating: .zero, count: operandSize)
   let resultL = [Float](repeating: .zero, count: sequenceDimension)
@@ -629,22 +582,22 @@ private func profileProblemSize(
   let resultDerivativeK = [Float](repeating: .zero, count: operandSize)
   let resultDerivativeQ = [Float](repeating: .zero, count: operandSize)
   resultO[0] = .nan
-  
+
   let bufferQ = createBuffer(network.Q, .Q)
   let bufferK = createBuffer(network.K, .K)
   let bufferV = createBuffer(network.V, .V)
   let bufferDerivativeO = createBuffer(network.dO, .dO)
-  
+
   let bufferL = createBuffer(resultL, .L)
   let bufferD = createBuffer(resultD, .D)
-  
+
   let bufferO = createBuffer(resultO, .O)
   let bufferDerivativeV = createBuffer(resultDerivativeV, .dV)
   let bufferDerivativeK = createBuffer(resultDerivativeK, .dK)
   let bufferDerivativeQ = createBuffer(resultDerivativeQ, .dQ)
-  
+
   // MARK: - GPU Commands
-  
+
   // - Parameter dispatchCount: Number of times to duplicate the FWD / BWD
   //                            combined pass.
   // - Returns: Latency of the entire command buffer, in seconds.
@@ -655,11 +608,11 @@ private func profileProblemSize(
     let commandQueue = MTLContext.global.commandQueue
     let commandBuffer = commandQueue.makeCommandBuffer()!
     let encoder = commandBuffer.makeComputeCommandEncoder()!
-    
+
     func ceilDivide(_ target: Int, _ granularity: UInt16) -> Int {
       (target + Int(granularity) - 1) / Int(granularity)
     }
-    
+
     // Bind all necessary MTLBuffer arguments before calling this function.
     func dispatch(
       kernel: AttentionKernel,
@@ -669,7 +622,7 @@ private func profileProblemSize(
       encoder.setComputePipelineState(pipeline)
       encoder.setThreadgroupMemoryLength(
         Int(kernel.threadgroupMemoryAllocation), index: 0)
-      
+
       let blockCount = ceilDivide(
         parallelizationDimension, kernel.blockDimensions.parallelization)
       let gridSize = MTLSize(
@@ -683,20 +636,20 @@ private func profileProblemSize(
       encoder.dispatchThreadgroups(
         gridSize, threadsPerThreadgroup: groupSize)
     }
-    
+
     encoder.setBuffer(bufferQ, offset: 0, index: 0)
     encoder.setBuffer(bufferK, offset: 0, index: 1)
     encoder.setBuffer(bufferV, offset: 0, index: 2)
     encoder.setBuffer(bufferO, offset: 0, index: 3)
-    
+
     encoder.setBuffer(bufferL, offset: 0, index: 4)
     encoder.setBuffer(bufferD, offset: 0, index: 5)
-    
+
     encoder.setBuffer(bufferDerivativeO, offset: 0, index: 6)
     encoder.setBuffer(bufferDerivativeV, offset: 0, index: 7)
     encoder.setBuffer(bufferDerivativeK, offset: 0, index: 8)
     encoder.setBuffer(bufferDerivativeQ, offset: 0, index: 9)
-    
+
     for _ in 0..<dispatchCount {
       switch benchmarkedKernel {
       case .forward:


### PR DESCRIPTION
Replaces __asm-based simdgroup_event::async_copy with LLVM IR intrinsics                                                                                                                             
emitted directly into monolithic kernel IR. Assembled in-process via
MetalASM — no Metal CLI tools required, works on both macOS and iOS.

Key changes:
- Emit complete kernel IR with async copy intrinsics (no __asm)
- In-process IR → bitcode → metallib via MetalASM
- Double-buffered K/V async copies in forward kernel
- Device load for Q (skip unnecessary TG copies)
- Forward + backward (bwd_q, bwd_kv) attention kernels
- Monolithic IR GEMM kernel
- AttentionDescriptor pipeline cache